### PR TITLE
Removes FreeBSD references

### DIFF
--- a/concept/root-directory-structure.md
+++ b/concept/root-directory-structure.md
@@ -23,7 +23,7 @@ By default, QuestDB's root directory will be the following:
 <!-- prettier-ignore-start -->
 
 <Tabs defaultValue="nix" values={[
-  { label: "Linux/FreeBSD", value: "nix" },
+  { label: "Linux", value: "nix" },
   { label: "macOS (Homebrew)", value: "macos" },
   { label: "Windows", value: "windows" },
 ]}>

--- a/quick-start.mdx
+++ b/quick-start.mdx
@@ -5,29 +5,27 @@ description:
   homebrew, our binaries, and more.
 ---
 
-import Screenshot from "@theme/Screenshot"
+import Screenshot from "@theme/Screenshot";
 
-import Button from "@theme/Button"
+import Button from "@theme/Button";
 
-import InterpolateReleaseData from "../src/components/InterpolateReleaseData"
+import InterpolateReleaseData from "../src/components/InterpolateReleaseData";
 
-import NoJrePrerequisite from
-"./quick-start-utils/\_no-jre-prerequisites.partial.mdx"
+import NoJrePrerequisite from "./quick-start-utils/_no-jre-prerequisites.partial.mdx";
 
-import CodeBlock from "@theme/CodeBlock"
+import CodeBlock from "@theme/CodeBlock";
 
-import { TabsPlatforms } from "../src/modules/TabsPlatforms"
+import { TabsPlatforms } from "../src/modules/TabsPlatforms";
 
-import RunWindows from "./quick-start-utils/\_run-windows.partial.mdx"
+import RunWindows from "./quick-start-utils/_run-windows.partial.mdx";
 
-import OptionsNotWindows from
-"./quick-start-utils/\_options-not-windows.partial.mdx"
+import OptionsNotWindows from "./quick-start-utils/_options-not-windows.partial.mdx";
 
-import OptionsWindows from "./quick-start-utils/\_options-windows.partial.mdx"
+import OptionsWindows from "./quick-start-utils/_options-windows.partial.mdx";
 
-import Tabs from "@theme/Tabs"
+import Tabs from "@theme/Tabs";
 
-import TabItem from "@theme/TabItem"
+import TabItem from "@theme/TabItem";
 
 This guide will get your first QuestDB instance running.
 
@@ -55,10 +53,13 @@ platform on the [official documentation](https://docs.docker.com/get-docker/).
 Once Docker is installed, you will need to pull QuestDB's image from
 [Docker Hub](https://hub.docker.com/r/questdb/questdb) and create a container:
 
-<InterpolateReleaseData renderText={(release) => (
-<CodeBlock className="language-shell">
-{`docker run \\   -p 9000:9000 -p 9009:9009 -p 8812:8812 -p 9003:9003 \\   questdb/questdb:${release.name}`}
-</CodeBlock> )} />
+<InterpolateReleaseData
+  renderText={(release) => (
+    <CodeBlock className="language-shell">
+      {`docker run \\   -p 9000:9000 -p 9009:9009 -p 8812:8812 -p 9003:9003 \\   questdb/questdb:${release.name}`}
+    </CodeBlock>
+  )}
+/>
 
 For deeper instructions, see the
 [Docker deployment guide](/docs/deployment/docker/).
@@ -80,9 +81,11 @@ On macOS, the location of the root directory of QuestDB and
 
 ### Binaries
 
-export const platforms = [ { label: "Linux", value: "linux" }, { label:
-"Windows", value: "windows" }, { label: "FreeBSD", value: "bsd" }, { label:
-"Any (no JVM)", value: "noJre" }, ]
+export const platforms = [
+  { label: "Linux", value: "linux" },
+  { label: "Windows", value: "windows" },
+  { label: "Any (no JVM)", value: "noJre" },
+];
 
 Download and run QuestDB via binaries.
 
@@ -149,7 +152,7 @@ Select your platform of choice:
 
 ## Run QuestDB
 
-<Tabs defaultValue="nix" values={[ { label: "Linux/FreeBSD/No JVM", value: "nix"
+<Tabs defaultValue="nix" values={[ { label: "Linux/No JVM", value: "nix"
 }, { label: "macOS (Homebrew)", value: "macos" }, { label: "Windows", value:
 "windows" }, ]}>
 

--- a/reference/command-line-options.md
+++ b/reference/command-line-options.md
@@ -19,7 +19,7 @@ import TabItem from "@theme/TabItem"
 
 <Tabs defaultValue="nix"
 values={[
-  { label: "Linux/FreeBSD", value: "nix" },
+  { label: "Linux", value: "nix" },
   { label: "macOS (Homebrew)", value: "macos" },
   { label: "Windows", value: "windows" },
 ]}>
@@ -86,7 +86,7 @@ questdb.exe [start|stop|status|install|remove] \
 
 <Tabs defaultValue="nix"
 values={[
-  { label: "Linux/FreeBSD", value: "nix" },
+  { label: "Linux", value: "nix" },
   { label: "macOS (Homebrew)", value: "macos" },
   { label: "Windows", value: "windows" },
 ]}>
@@ -127,7 +127,7 @@ will be the following:
 <!-- prettier-ignore-start -->
 
 <Tabs defaultValue="nix" values={[
-  { label: "Linux/FreeBSD", value: "nix" },
+  { label: "Linux", value: "nix" },
   { label: "macOS (Homebrew)", value: "macos" },
   { label: "Windows", value: "windows" },
 ]}>
@@ -179,7 +179,7 @@ C:\Windows\System32\qdbroot
 <!-- prettier-ignore-start -->
 
 <Tabs defaultValue="nix" values={[
-  { label: "Linux/FreeBSD", value: "nix" },
+  { label: "Linux", value: "nix" },
   { label: "macOS (Homebrew)", value: "macos" },
   { label: "Windows", value: "windows" },
 ]}>
@@ -223,7 +223,7 @@ questdb.exe stop
 <!-- prettier-ignore-start -->
 
 <Tabs defaultValue="nix" values={[
-  { label: "Linux/FreeBSD", value: "nix" },
+  { label: "Linux", value: "nix" },
   { label: "macOS (Homebrew)", value: "macos" },
   { label: "Windows", value: "windows" },
 ]}>


### PR DESCRIPTION
FreeBSD is not tested and therefore not officially supported.

The market share does not appear significant.

If demand proves that to be false, we can revisit.

Pairs with: https://github.com/questdb/questdb.io/pull/2378