### PR TITLE
Add systemd changes to file descriptor limit docs

### DIFF
--- a/deployment/capacity-planning.md
+++ b/deployment/capacity-planning.md
@@ -352,6 +352,16 @@ sysctl -p
 sysctl fs.file-max
 ```
 
+#### Extra steps for systemd
+
+If you are running the server with `systemd`, you will also need to set the `LimitNOFILE` property in your service file.
+
+If you have followed the [setup guide](https://questdb.io/docs/deployment/systemd/), then the file should be called `questdb.service` and located at `~/.config/systemd/user/questdb.service`.
+
+Set this property to at least `1048576`, or higher if you have set higher OS-wide limits. 
+
+Then restart the service. If you have configured these settings correctly, any warnings in the web console should now be cleared.
+
 #### Setting system-wide open file limit on MacOS:
 
 On MacOS, the system-wide limit can be modified by using `launchctl`:

--- a/deployment/capacity-planning.md
+++ b/deployment/capacity-planning.md
@@ -354,7 +354,7 @@ sysctl fs.file-max
 
 #### Extra steps for systemd
 
-If you are running the server with `systemd`, you will also need to set the `LimitNOFILE` property in your service file.
+If you are running the QuestDB using `systemd`, you will also need to set the `LimitNOFILE` property in your service file.
 
 If you have followed the [setup guide](https://questdb.io/docs/deployment/systemd/), then the file should be called `questdb.service` and located at `~/.config/systemd/user/questdb.service`.
 

--- a/deployment/capacity-planning.md
+++ b/deployment/capacity-planning.md
@@ -358,7 +358,7 @@ If you are running the server with `systemd`, you will also need to set the `Lim
 
 If you have followed the [setup guide](https://questdb.io/docs/deployment/systemd/), then the file should be called `questdb.service` and located at `~/.config/systemd/user/questdb.service`.
 
-Set this property to at least `1048576`, or higher if you have set higher OS-wide limits. 
+Add this property to the `[Service]` section, setting it to at least `1048576`, or higher if you have set higher OS-wide limits. 
 
 Then restart the service. If you have configured these settings correctly, any warnings in the web console should now be cleared.
 

--- a/deployment/capacity-planning.md
+++ b/deployment/capacity-planning.md
@@ -356,7 +356,7 @@ sysctl fs.file-max
 
 If you are running the QuestDB using `systemd`, you will also need to set the `LimitNOFILE` property in your service file.
 
-If you have followed the [setup guide](https://questdb.io/docs/deployment/systemd/), then the file should be called `questdb.service` and located at `~/.config/systemd/user/questdb.service`.
+If you have followed the [setup guide](https://questdb.io/docs/deployment/systemd/), then the file should be called `questdb.service` and be located at `~/.config/systemd/user/questdb.service`.
 
 Add this property to the `[Service]` section, setting it to at least `1048576`, or higher if you have set higher OS-wide limits. 
 


### PR DESCRIPTION
When running the service under systemd, you also need to set LimitNOFILE in the service config.