### PR TITLE
bump version of questdb connect at superset docs

### DIFF
--- a/third-party-tools/superset.md
+++ b/third-party-tools/superset.md
@@ -39,7 +39,7 @@ git clone https://github.com/apache/superset.git
 
 ```bash
 touch ./docker/requirements-local.txt
-echo "questdb-connect==1.0.11" > docker/requirements-local.txt
+echo "questdb-connect==1.0.12" > docker/requirements-local.txt
 ```
 
 4. Run Apache Superset:
@@ -67,7 +67,7 @@ Superset without Docker, you need to install the following requirements :
 Install QuestDB Connect using `pip`:
 
 ```bash
-pip install 'questdb-connect==1.0.11'
+pip install 'questdb-connect==1.0.12'
 ```
 
 ## Connecting QuestDB to Superset


### PR DESCRIPTION
Version was pointing to 1.0.11 instead of 1.0.12