### PR TITLE
Update deduplication.md to match 8.1.1 dedup types

### DIFF
--- a/concept/deduplication.md
+++ b/concept/deduplication.md
@@ -66,7 +66,7 @@ criteria are set by defining a column list in the `UPSERT KEYS` clause in the
 
 `UPSERT KEYS` can be changed at any time. It can contain one or more columns.
 
-Please be aware that the [Designated Timestamp](/docs/concept/designated-timestamp) 
+Please be aware that the [designated Timestamp](/docs/concept/designated-timestamp) 
 column must always be included in the `UPSERT KEYS` list.
 
 

--- a/concept/deduplication.md
+++ b/concept/deduplication.md
@@ -70,7 +70,7 @@ However, there are some limitations on the `UPSERT KEYS` list:
 
 - The [Designated Timestamp](/docs/concept/designated-timestamp) column must be
   included in the `UPSERT KEYS` list.
-- Columns of [VARCHAR, STRING and BINARY](/docs/reference/sql/datatypes) types cannot be
+- Columns of [BINARY](/docs/reference/sql/datatypes) types cannot be
   used in the `UPSERT KEYS` list.
 
 ## Example

--- a/concept/deduplication.md
+++ b/concept/deduplication.md
@@ -66,12 +66,9 @@ criteria are set by defining a column list in the `UPSERT KEYS` clause in the
 
 `UPSERT KEYS` can be changed at any time. It can contain one or more columns.
 
-However, there are some limitations on the `UPSERT KEYS` list:
+Please be aware that the [Designated Timestamp](/docs/concept/designated-timestamp) 
+column must always be included in the `UPSERT KEYS` list.
 
-- The [Designated Timestamp](/docs/concept/designated-timestamp) column must be
-  included in the `UPSERT KEYS` list.
-- Columns of [BINARY](/docs/reference/sql/datatypes) types cannot be
-  used in the `UPSERT KEYS` list.
 
 ## Example
 

--- a/reference/sql/alter-table-enable-deduplication.md
+++ b/reference/sql/alter-table-enable-deduplication.md
@@ -22,12 +22,8 @@ Enable storage level data deduplication on inserts and configures `UPSERT KEYS`.
 
 ![Flow chart showing the syntax of the ALTER TABLE DEDUP ENABLE statement](/img/docs/diagrams/enableDedup.svg)
 
-`UPSERT KEYS` list can include one or more columns with the following rules:
-
-- The [designated Timestamp](/docs/concept/designated-timestamp) column must be
+`UPSERT KEYS` list can include one or more columns. The [designated Timestamp](/docs/concept/designated-timestamp) column must be
   included in the `UPSERT KEYS` list.
-- Columns of [STRING and BINARY](/docs/reference/sql/datatypes) types cannot be
-  used in the `UPSERT KEYS` list.
 
 Running `ALTER TABLE DEDUP ENABLE` on a table that already has deduplication
 enabled is not an error.

--- a/reference/sql/alter-table-enable-deduplication.md
+++ b/reference/sql/alter-table-enable-deduplication.md
@@ -22,7 +22,7 @@ Enable storage level data deduplication on inserts and configures `UPSERT KEYS`.
 
 ![Flow chart showing the syntax of the ALTER TABLE DEDUP ENABLE statement](/img/docs/diagrams/enableDedup.svg)
 
-`UPSERT KEYS` list can include one or more columns. The [designated Timestamp](/docs/concept/designated-timestamp) column must be
+`UPSERT KEYS` list can include one or more columns. The [designated timestamp](/docs/concept/designated-timestamp) column must be
   included in the `UPSERT KEYS` list.
 
 Running `ALTER TABLE DEDUP ENABLE` on a table that already has deduplication


### PR DESCRIPTION
removing string, varchar, and binary from unsupported upsert keys