### PR TITLE
Separate ASOF JOIN from JOIN

### DIFF
--- a/concept/designated-timestamp.md
+++ b/concept/designated-timestamp.md
@@ -47,6 +47,7 @@ Electing a designated timestamp allows you to:
 - Partition tables by time range. For more information, see the
   [partitions reference](/docs/concept/partitions/).
 - Use time series joins such as `ASOF JOIN`. For more information, see the
+  [ASOF JOIN reference](/docs/reference/sql/asof-join/) or the more general
   [JOIN reference](/docs/reference/sql/join/).
 - Optimize queries with [Interval scan](/docs/concept/interval-scan)
 

--- a/introduction.md
+++ b/introduction.md
@@ -70,8 +70,8 @@ Greatest hits include:
   into concise intervals
 - [`LATEST ON`](/docs/reference/sql/latest-on/) for latest values within
   multiple series within a table
-- [`ASOF JOIN`](/docs/reference/sql/join/#asof-join) to associate timestamps
-  between a series based on proximity; no extra indices required
+- [`ASOF JOIN`](/docs/reference/sql/asof-join/) to associate timestamps between
+  a series based on proximity; no extra indices required
 
 ## Benefits of QuestDB {#benefits}
 

--- a/operations/rbac.md
+++ b/operations/rbac.md
@@ -731,12 +731,12 @@ GRANT SELECT ON table1(col4) TO user1;
 
 Since QuestDB is a [time-series database](/glossary/time-series-database/), the
 designated timestamp column is treated on a special way. Some functionality,
-such as [SAMPLE BY](/docs/reference/sql/sample-by),
-[LATEST ON](/docs/reference/sql/latest-on) or
-[ASOF JOIN](/docs/reference/sql/join/#asof-join), require a designated
-timestamp. If a user can access only some columns of a table, but not the
-designated timestamp, then these operations would become unavailable to the
-user. It is something of a dependency.
+such as [SAMPLE BY](/docs/reference/sql/sample-by/),
+[LATEST ON](/docs/reference/sql/latest-on/) or
+[ASOF JOIN](/docs/reference/sql/asof-join/), require a designated timestamp. If
+a user can access only some columns of a table, but not the designated
+timestamp, then these operations would become unavailable to the user. It is
+something of a dependency.
 
 As a solution, QuestDB derives permissions for the designated timestamp column
 based on the access granted to other columns of the table. If a user is granted

--- a/reference/sql/asof-join.md
+++ b/reference/sql/asof-join.md
@@ -1,0 +1,249 @@
+---
+title: ASOF JOIN keyword
+sidebar_label: ASOF JOIN
+description:
+  Learn how to use the powerful time-series ASOF JOIN SQL keyword from our
+  concise and clea reference documentation.
+---
+
+ASOF JOIN is a powerful SQL keyword that allows you to join two time-series
+tables.
+
+It is a variant of the [`JOIN` keyword](/docs/reference/sql/join/) and shares
+many of its execution traits.
+
+This document will demonstrate how to utilize them, and link to other relevant
+JOIN context.
+
+## JOIN overview
+
+The JOIN operation is broken into three components:
+
+- Select clause
+- Join claus
+- Where clause
+
+This document will demosntrate the JOIN clause, where the other keywords
+demonstrate their respective clauses.
+
+Visualized, a JOIN operation looks like this:
+
+![Flow chart showing the syntax of the high-level syntax of the JOIN keyword](/img/docs/diagrams/joinOverview.svg)
+
+- `selectClause` - see the [SELECT](/docs/reference/sql/select/) reference docs
+  for more information.
+
+- `joinClause` `ASOF JOIN` with an optional `ON` clause which allows only the
+  `=` predicate:
+
+  ![Flow chart showing the syntax of the ASOF, LT, and SPLICE JOIN keyword](/img/docs/diagrams/AsofLtSpliceJoin.svg)
+
+- `whereClause` - see the [WHERE](/docs/reference/sql/where/) reference docs for
+  more information.
+
+In addition, the following are items of import:
+
+- Columns from joined tables are combined in a single row.
+
+- Columns with the same name originating from different tables will be
+  automatically aliased into a unique column namespace of the result set.
+
+- Though it is usually preferable to explicitly specify join conditions, QuestDB
+  will analyze `WHERE` clauses for implicit join conditions and will derive
+  transient join conditions where necessary.
+
+### Execution order
+
+Join operations are performed in order of their appearance in a SQL query.
+
+Read more about execution order in the
+[JOIN reference documentation](/docs/reference/sql/join/).
+
+## ASOF JOIN
+
+`ASOF JOIN` joins two different time-series measured.
+
+For each row in the first time-series, the `ASOF JOIN` takes from the second
+time-series a timestamp that meets both of the following criteria:
+
+- The timestamp is the closest to the first timestamp.
+- The timestamp is **strictly prior or equal to** the first timestamp.
+
+### Example
+
+Given the following tables:
+
+Table `buy` (the left table):
+
+<div className="pink-table">
+
+| timestamp                   | price    |
+| --------------------------- | -------- |
+| 2024-06-22T00:00:00.039906Z | 0.092014 |
+| 2024-06-22T00:00:00.343909Z | 9.805    |
+| 2024-06-22T00:00:00.349387Z | 134.56   |
+| 2024-06-22T00:00:00.349387Z | 134.56   |
+| 2024-06-22T00:00:00.446196Z | 9.805    |
+
+</div>
+
+The `sell` table (the right table):
+
+<div className="blue-table">
+
+| timestamp                   | price    |
+| --------------------------- | -------- |
+| 2024-06-22T00:00:00.222534Z | 64120.28 |
+| 2024-06-22T00:00:00.222534Z | 64120.28 |
+| 2024-06-22T00:00:00.222534Z | 64116.74 |
+| 2024-06-22T00:00:00.222534Z | 64116.5  |
+| 2024-06-22T00:00:00.543826Z | 134.56   |
+
+</div>
+
+An `ASOF JOIN` query can look like the following:
+
+```questdb-sql
+WITH
+buy AS (  -- select the first 5 buys in June 22
+   SELECT timestamp, price FROM trades
+   WHERE timestamp IN '2024-06-22' AND side = 'buy' LIMIT 5
+   ),
+sell AS ( -- select the first 5 sells in June 22
+   SELECT timestamp, price FROM trades
+   WHERE timestamp IN '2024-06-22' AND side = 'sell' LIMIT 5
+   )
+SELECT
+   buy.timestamp, sell.timestamp, buy.price, sell.price
+FROM buy ASOF JOIN sell;
+```
+
+This is the JOIN result:
+
+<div className="table-alternate">
+
+| timestamp                   | timestamp1                  | price    | price1  |
+| --------------------------- | --------------------------- | -------- | ------- |
+| 2024-06-22T00:00:00.039906Z | NULL                        | 0.092014 | NULL    |
+| 2024-06-22T00:00:00.343909Z | 2024-06-22T00:00:00.222534Z | 9.805    | 64116.5 |
+| 2024-06-22T00:00:00.349387Z | 2024-06-22T00:00:00.222534Z | 134.56   | 64116.5 |
+| 2024-06-22T00:00:00.349387Z | 2024-06-22T00:00:00.222534Z | 134.56   | 64116.5 |
+| 2024-06-22T00:00:00.446196Z | 2024-06-22T00:00:00.222534Z | 9.805    | 64116.5 |
+
+</div>
+
+The result has all rows from the `buys` table joined with rows from the `sells`
+table. For each timestamp from the `buys` table, the query looks for a timestamp
+that is equal or prior to it from the `sells` table. If no matching timestamp is
+found, NULL is inserted.
+
+### Using `ON` for matching column value
+
+An additional `ON` clause can be used to join the tables based on the value of a
+selected column.
+
+The query above does not use the optional `ON` clause. If both tables store data
+for multiple symbols, `ON` clause provides a way to find sells for buys with
+matching symbol value.
+
+Table `buy` (the left table):
+
+<div className="pink-table">
+
+| timestamp                   | symbol  | price    |
+| --------------------------- | ------- | -------- |
+| 2024-06-22T00:00:00.039906Z | XLM-USD | 0.092014 |
+| 2024-06-22T00:00:00.039906Z | UNI-USD | 9.805    |
+| 2024-06-22T00:00:00.349387Z | SOL-USD | 134.56   |
+| 2024-06-22T00:00:00.349387Z | SOL-USD | 134.56   |
+| 2024-06-22T00:00:00.446196Z | UNI-USD | 9.805    |
+
+</div>
+
+The `sell` table (the right table):
+
+<div className="blue-table">
+
+| timestamp                   | symbol  | price    |
+| --------------------------- | ------- | -------- |
+| 2024-06-21T23:59:59.187884Z | SOL-USD | 134.54   |
+| 2024-06-21T23:59:59.878276Z | UNI-USD | 9.804    |
+| 2024-06-22T00:00:00.222534Z | BTC-USD | 64120.28 |
+| 2024-06-22T00:00:00.543826Z | SOL-USD | 134.56   |
+| 2024-06-22T00:00:00.644399Z | SOL-USD | 134.56   |
+
+</div>
+
+Notice how both tables have a new column `symbol` that stores the stock name.
+
+The `ON` clause allows you to match the value of the `symbol` column in the
+`buys` table with that in the `sells` table:
+
+```questdb-sql
+WITH
+buy AS (  -- select the first 5 buys in June 22
+   SELECT * FROM trades
+   WHERE timestamp IN '2024-06-22' AND side = 'buy' LIMIT 5
+   ),
+sell AS ( -- sells in the last second of June 21 and 1 second later
+   SELECT * FROM trades
+   WHERE timestamp IN '2024-06-21T23:59:59;1s' AND side = 'sell'
+   )
+SELECT
+   buy.timestamp,  sell.timestamp, buy.symbol,
+   (buy.price - sell.price) spread
+FROM buy ASOF JOIN sell ON (symbol);
+
+```
+
+The above query returns these results:
+
+<div className="table-alternate">
+
+| timestamp                   | timestamp1                  | symbol  | spread |
+| --------------------------- | --------------------------- | ------- | ------ |
+| 2024-06-22T00:00:00.039906Z | NULL                        | XLM-USD | NULL   |
+| 2024-06-22T00:00:00.343909Z | 2024-06-21T23:59:59.878276Z | UNI-USD | 0.0009 |
+| 2024-06-22T00:00:00.349387Z | 2024-06-21T23:59:59.187884Z | SOL-USD | 0.02   |
+| 2024-06-22T00:00:00.349387Z | 2024-06-21T23:59:59.187884Z | SOL-USD | 0.02   |
+| 2024-06-22T00:00:00.446196Z | 2024-06-21T23:59:59.878276Z | UNI-USD | 0.0009 |
+
+</div>
+
+This query returns all rows from the `buy` table joined with records from the
+`sell` table that meet both the following criterion:
+
+- The `symbol` column of the two tables has the same value
+- The timestamp of the `sell` record is prior to or equal to the timestamp of
+  the `buy` record.
+
+The XLM-USD record in the `buy` table is not joined with any record in the
+`sell` table because there is no record in the `sell` table with the same stock
+name and a timestamp prior to or equal to the timestamp of the XLM-USD record.
+Note how the `sell` table has three rows with the SOL-USD symbol, but both of
+the SOL-USD in the `buy` table are matching to the first entry, as it is the
+only timestamp which is equal or prior.
+
+### Timestamp considerations
+
+`ASOF` join can be performed only on tables or result sets that are ordered by
+time. When a table is created with a
+[designated timestamp](/docs/concept/designated-timestamp/) the order of records
+is enforced and the timestamp column name is in the table metadata. `ASOF` join
+uses this timestamp column from metadata.
+
+:::caution
+
+`ASOF` join does not check timestamp order, if data is not in chronological
+order, the join result is non-deterministic.
+
+:::
+
+In case tables do not have a designated timestamp column, but data is in
+chronological order, timestamp columns can be specified at runtime:
+
+```questdb-sql
+SELECT *
+FROM (a timestamp(ts))
+ASOF JOIN (b timestamp (ts));
+```

--- a/reference/sql/asof-join.md
+++ b/reference/sql/asof-join.md
@@ -247,3 +247,12 @@ SELECT *
 FROM (a timestamp(ts))
 ASOF JOIN (b timestamp (ts));
 ```
+
+## SPLICE JOIN
+
+Want to join all records from both tables?
+
+`SPLICE JOIN` is a full `ASOF JOIN`.
+
+Read the [JOIN reference](/docs/reference/sql/join/#splice-join) for more
+information on SPLICE JOIN.

--- a/reference/sql/asof-join.md
+++ b/reference/sql/asof-join.md
@@ -3,7 +3,7 @@ title: ASOF JOIN keyword
 sidebar_label: ASOF JOIN
 description:
   Learn how to use the powerful time-series ASOF JOIN SQL keyword from our
-  concise and clea reference documentation.
+  concise and clear reference documentation.
 ---
 
 ASOF JOIN is a powerful SQL keyword that allows you to join two time-series
@@ -20,10 +20,10 @@ JOIN context.
 The JOIN operation is broken into three components:
 
 - Select clause
-- Join claus
+- Join clause
 - Where clause
 
-This document will demosntrate the JOIN clause, where the other keywords
+This document will demonstrate the JOIN clause, where the other keywords
 demonstrate their respective clauses.
 
 Visualized, a JOIN operation looks like this:
@@ -107,11 +107,11 @@ An `ASOF JOIN` query can look like the following:
 WITH
 buy AS (  -- select the first 5 buys in June 22
    SELECT timestamp, price FROM trades
-   WHERE timestamp IN '2024-06-22' AND side = 'buy' LIMIT 5
+   WHERE timestamp = '2024-06-22' AND side = 'buy' LIMIT 5
    ),
 sell AS ( -- select the first 5 sells in June 22
    SELECT timestamp, price FROM trades
-   WHERE timestamp IN '2024-06-22' AND side = 'sell' LIMIT 5
+   WHERE timestamp = '2024-06-22' AND side = 'sell' LIMIT 5
    )
 SELECT
    buy.timestamp, sell.timestamp, buy.price, sell.price

--- a/reference/sql/join.md
+++ b/reference/sql/join.md
@@ -52,8 +52,8 @@ transient join conditions where necessary.
 ## Execution order
 
 Join operations are performed in order of their appearance in a SQL query. The
-following query performs a join on a table with a very small table (just one
-row in this example) and a bigger table with 10 million rows:
+following query performs a join on a table with a very small table (just one row
+in this example) and a bigger table with 10 million rows:
 
 ```questdb-sql
 WITH
@@ -79,10 +79,10 @@ INNER JOIN Lookup
   ON Lookup.symbol = Manytrades.symbol;
 ```
 
-As a general rule, whenever you have a table significantly larger than the other, try
-to use the large one first. If you use `EXPLAIN` with the queries above, you should
-see the first version needs to Hash over 10 million rows, while the second version
-needs to Hash only over 1 row.
+As a general rule, whenever you have a table significantly larger than the
+other, try to use the large one first. If you use `EXPLAIN` with the queries
+above, you should see the first version needs to Hash over 10 million rows,
+while the second version needs to Hash only over 1 row.
 
 ## Implicit joins
 
@@ -201,16 +201,22 @@ The result of both queries is the following:
 
 </div>
 
+## ASOF JOIN
+
+ASOF JOIN is a powerful time-series join extension.
+
+It has its own page, [ASOF JOIN](/docs/reference/sql/asof-join/).
+
 ## (INNER) JOIN
 
 `(INNER) JOIN` returns rows from two tables where the records on the compared
 column have matching values in both tables. `JOIN` is interpreted as
 `INNER JOIN` by default, making the `INNER` keyword implicit.
 
-The query we just saw above is an example. It returns the `symbol`, `side`
-and `total` from the `mayTrades` subquery, and adds the `symbol`, `side`,
-and `total` from the `juneTrades` subquery. Both tables are matched based
-on the `symbol` and `side`, as specified on the `ON` condition.
+The query we just saw above is an example. It returns the `symbol`, `side` and
+`total` from the `mayTrades` subquery, and adds the `symbol`, `side`, and
+`total` from the `juneTrades` subquery. Both tables are matched based on the
+`symbol` and `side`, as specified on the `ON` condition.
 
 ## LEFT (OUTER) JOIN
 
@@ -231,9 +237,9 @@ LEFT OUTER JOIN Lookup
   ON Lookup.symbol = Manytrades.symbol;
 ```
 
-In this example, the result will have 100 rows, one for each row on the `ManyTrades`
-subquery. When there is no match with the `Lookup` subquery, the columns `Symbol1`
-and `Description` will be `null`.
+In this example, the result will have 100 rows, one for each row on the
+`ManyTrades` subquery. When there is no match with the `Lookup` subquery, the
+columns `Symbol1` and `Description` will be `null`.
 
 ```sql
 -- Omitting 'OUTER' makes no difference:
@@ -261,18 +267,18 @@ SELECT * from ManyTrades LEFT OUTER JOIN Lookup
   WHERE Lookup.Symbol = NULL;
 ```
 
-In this case, the result has 71 rows out of the 100 in the larger table, and
-the columns corresponding to the `Lookup` table are all `NULL`.
+In this case, the result has 71 rows out of the 100 in the larger table, and the
+columns corresponding to the `Lookup` table are all `NULL`.
 
 ## CROSS JOIN
 
 `CROSS JOIN` returns the Cartesian product of the two tables being joined and
 can be used to create a table with all possible combinations of columns.
 
-The following query is joining a table (a subquery in this case) with itself,
-to compare row by row if we have any rows with exactly the same values for
-all the columns except the timestamp, and if the timestamps are within 10
-seconds from each other:
+The following query is joining a table (a subquery in this case) with itself, to
+compare row by row if we have any rows with exactly the same values for all the
+columns except the timestamp, and if the timestamps are within 10 seconds from
+each other:
 
 ```questdb-sql
 -- detect potential duplicates, with same values
@@ -294,193 +300,6 @@ AND t.amount = t2.amount;
 :::note
 
 `CROSS JOIN` does not have an `ON` clause.
-
-:::
-
-## ASOF JOIN
-
-`ASOF JOIN` joins two different time-series measured. For each row in the first
-time-series, the `ASOF JOIN` takes from the second time-series a timestamp that
-meets both of the following criteria:
-
-- The timestamp is the closest to the first timestamp.
-- The timestamp is **strictly prior or equal to** the first timestamp.
-
-### Example
-
-Given the following tables:
-
-Table `buy` (the left table):
-
-<div className="pink-table">
-
-| timestamp                   | price    |
-| --------------------------- | -------- |
-| 2024-06-22T00:00:00.039906Z | 0.092014 |
-| 2024-06-22T00:00:00.343909Z | 9.805    |
-| 2024-06-22T00:00:00.349387Z | 134.56   |
-| 2024-06-22T00:00:00.349387Z | 134.56   |
-| 2024-06-22T00:00:00.446196Z | 9.805    |
-
-</div>
-
-The `sell` table (the right table):
-
-<div className="blue-table">
-
-| timestamp                   | price    |
-| --------------------------- | -------- |
-| 2024-06-22T00:00:00.222534Z | 64120.28 |
-| 2024-06-22T00:00:00.222534Z | 64120.28 |
-| 2024-06-22T00:00:00.222534Z | 64116.74 |
-| 2024-06-22T00:00:00.222534Z | 64116.5  |
-| 2024-06-22T00:00:00.543826Z | 134.56   |
-
-</div>
-
-An `ASOF JOIN` query can look like the following:
-
-```questdb-sql
-WITH
-buy AS (  -- select the first 5 buys in June 22
-   SELECT timestamp, price FROM trades
-   WHERE timestamp IN '2024-06-22' AND side = 'buy' LIMIT 5
-   ),
-sell AS ( -- select the first 5 sells in June 22
-   SELECT timestamp, price FROM trades
-   WHERE timestamp IN '2024-06-22' AND side = 'sell' LIMIT 5
-   )
-SELECT
-   buy.timestamp, sell.timestamp, buy.price, sell.price
-FROM buy ASOF JOIN sell;
-```
-
-This is the JOIN result:
-
-<div className="table-alternate">
-
-| timestamp                   | timestamp1                  | price    | price1  |
-| --------------------------- | --------------------------- | -------- | ------- |
-| 2024-06-22T00:00:00.039906Z | NULL                        | 0.092014 | NULL    |
-| 2024-06-22T00:00:00.343909Z | 2024-06-22T00:00:00.222534Z | 9.805    | 64116.5 |
-| 2024-06-22T00:00:00.349387Z | 2024-06-22T00:00:00.222534Z | 134.56   | 64116.5 |
-| 2024-06-22T00:00:00.349387Z | 2024-06-22T00:00:00.222534Z | 134.56   | 64116.5 |
-| 2024-06-22T00:00:00.446196Z | 2024-06-22T00:00:00.222534Z | 9.805    | 64116.5 |
-
-</div>
-
-The result has all rows from the `buys` table joined with rows from the `sells`
-table. For each timestamp from the `buys` table, the query looks for a timestamp
-that is equal or prior to it from the `sells` table. If no matching timestamp is
-found, NULL is inserted.
-
-### Using `ON` for matching column value
-
-An additional `ON` clause can be used to join the tables based on the value of a
-selected column.
-
-The query above does not use the optional `ON` clause. If both tables store data
-for multiple symbols, `ON` clause provides a way to find sells for buys with
-matching symbol value.
-
-Table `buy` (the left table):
-
-<div className="pink-table">
-
-| timestamp                   | symbol  | price    |
-| --------------------------- | ------- | -------- |
-| 2024-06-22T00:00:00.039906Z | XLM-USD | 0.092014 |
-| 2024-06-22T00:00:00.039906Z | UNI-USD | 9.805    |
-| 2024-06-22T00:00:00.349387Z | SOL-USD | 134.56   |
-| 2024-06-22T00:00:00.349387Z | SOL-USD | 134.56   |
-| 2024-06-22T00:00:00.446196Z | UNI-USD | 9.805    |
-
-</div>
-
-The `sell` table (the right table):
-
-<div className="blue-table">
-
-| timestamp                   | symbol  | price    |
-| --------------------------- | ------- | -------- |
-| 2024-06-21T23:59:59.187884Z | SOL-USD | 134.54   |
-| 2024-06-21T23:59:59.878276Z | UNI-USD | 9.804    |
-| 2024-06-22T00:00:00.222534Z | BTC-USD | 64120.28 |
-| 2024-06-22T00:00:00.543826Z | SOL-USD | 134.56   |
-| 2024-06-22T00:00:00.644399Z | SOL-USD | 134.56   |
-
-</div>
-
-Notice how both tables have a new column `symbol` that stores the stock name. The
-`ON` clause allows you to match the value of the `symbol` column in the `buys`
-table with that in the `sells` table:
-
-```questdb-sql
-WITH
-buy AS (  -- select the first 5 buys in June 22
-   SELECT * FROM trades
-   WHERE timestamp IN '2024-06-22' AND side = 'buy' LIMIT 5
-   ),
-sell AS ( -- sells in the last second of June 21 and 1 second later
-   SELECT * FROM trades
-   WHERE timestamp IN '2024-06-21T23:59:59;1s' AND side = 'sell'
-   )
-SELECT
-   buy.timestamp,  sell.timestamp, buy.symbol,
-   (buy.price - sell.price) spread
-FROM buy ASOF JOIN sell ON (symbol);
-
-```
-
-The above query returns these results:
-
-<div className="table-alternate">
-
-| timestamp                   | timestamp1                  | symbol  | spread |
-| --------------------------- | --------------------------- | ------- | ------ |
-| 2024-06-22T00:00:00.039906Z | NULL                        | XLM-USD | NULL   |
-| 2024-06-22T00:00:00.343909Z | 2024-06-21T23:59:59.878276Z | UNI-USD | 0.0009 |
-| 2024-06-22T00:00:00.349387Z | 2024-06-21T23:59:59.187884Z | SOL-USD | 0.02   |
-| 2024-06-22T00:00:00.349387Z | 2024-06-21T23:59:59.187884Z | SOL-USD | 0.02   |
-| 2024-06-22T00:00:00.446196Z | 2024-06-21T23:59:59.878276Z | UNI-USD | 0.0009 |
-
-</div>
-
-This query returns all rows from the `buy` table joined with records from the
-`sell` table that meet both the following criterion:
-
-- The `symbol` column of the two tables has the same value
-- The timestamp of the `sell` record is prior to or equal to the timestamp of
-  the `buy` record.
-
-The XLM-USD record in the `buy` table is not joined with any record in the `sell`
-table because there is no record in the `sell` table with the same stock name
-and a timestamp prior to or equal to the timestamp of the XLM-USD record. Note
-how the `sell` table has three rows with the SOL-USD symbol, but both of the
-SOL-USD in the `buy` table are matching to the first entry, as it is the only
-timestamp which is equal or prior.
-
-### Timestamp considerations
-
-`ASOF` join can be performed only on tables or result sets that are ordered by
-time. When a table is created with a
-[designated timestamp](/docs/concept/designated-timestamp/) the order of records
-is enforced and the timestamp column name is in the table metadata. `ASOF` join
-uses this timestamp column from metadata.
-
-In case tables do not have a designated timestamp column, but data is in
-chronological order, timestamp columns can be specified at runtime:
-
-```questdb-sql
-SELECT *
-FROM (a timestamp(ts))
-ASOF JOIN (b timestamp (ts));
-```
-
-:::caution
-
-`ASOF` join does not check timestamp order, if data is not in chronological
-order, the join result is non-deterministic.
 
 :::
 
@@ -549,18 +368,20 @@ The query above returns the following results:
 
 </div>
 
-Notice how the first record in the `tradesA` table is not joined with any record in
-the `tradesB` table. This is because there is no record in the `tradesB` table with a
-timestamp prior to the timestamp of the first record in the `tradesA` table.
+Notice how the first record in the `tradesA` table is not joined with any record
+in the `tradesB` table. This is because there is no record in the `tradesB`
+table with a timestamp prior to the timestamp of the first record in the
+`tradesA` table.
 
-Similarly, the second record in the `tradesB` table is joined with the first record
-in the `tradesA` table because the timestamp of the first record in the `tradesB`
-table is prior to the timestamp of the second record in the `tradesA` table.
+Similarly, the second record in the `tradesB` table is joined with the first
+record in the `tradesA` table because the timestamp of the first record in the
+`tradesB` table is prior to the timestamp of the second record in the `tradesA`
+table.
 
 :::note
 
-As seen on this example, `LT` join is often useful to join a table to itself in order
-to get preceding values for every row.
+As seen on this example, `LT` join is often useful to join a table to itself in
+order to get preceding values for every row.
 
 :::
 

--- a/reference/sql/overview.md
+++ b/reference/sql/overview.md
@@ -404,7 +404,6 @@ Parquet files can be read and thus queried by QuestDB.
 QuestDB is shipped with a demo Parquet file, `trades.parquet`, which can be
 queried using the `parquet_read` function.
 
-
 Example:
 
 ```questdb-sql title="read_parquet example"
@@ -416,10 +415,12 @@ WHERE
   side = 'buy';
 ```
 
-The trades.parquet file is located in the `import` subdirectory inside the QuestDB root directory. 
-Drop your own Parquet files to the import directory and query them using the `parquet_read()` function.
+The trades.parquet file is located in the `import` subdirectory inside the
+QuestDB root directory. Drop your own Parquet files to the import directory and
+query them using the `parquet_read()` function.
 
-You can change the allowed directory by setting the `cairo.sql.copy.root` configuration key.
+You can change the allowed directory by setting the `cairo.sql.copy.root`
+configuration key.
 
 For more information, see the
 [Parquet documentation](/docs/reference/function/parquet/).
@@ -450,8 +451,8 @@ And to learn about some of our favourite, most powerful syntax:
   into concise intervals
 - [`LATEST ON`](/docs/reference/sql/latest-on/) for latest values within
   multiple series within a table
-- [`ASOF JOIN`](/docs/reference/sql/join/#asof-join) to associate timestamps
-  between a series based on proximity; no extra indices required
+- [`ASOF JOIN`](/docs/reference/sql/asof-join/) to associate timestamps between
+  a series based on proximity; no extra indices required
 
 Looking for visuals?
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -124,6 +124,16 @@ module.exports = {
           label: "SQL Syntax",
           items: [
             {
+              id: "reference/sql/acl/add-user",
+              type: "doc",
+              customProps: { tag: "Enterprise" },
+            },
+            {
+              id: "reference/sql/acl/alter-service-account",
+              type: "doc",
+              customProps: { tag: "Enterprise" },
+            },
+            {
               type: "category",
               label: "ALTER COLUMN",
               items: [
@@ -153,20 +163,11 @@ module.exports = {
               ],
             },
             {
-              id: "reference/sql/acl/add-user",
-              type: "doc",
-              customProps: { tag: "Enterprise" },
-            },
-            {
-              id: "reference/sql/acl/alter-service-account",
-              type: "doc",
-              customProps: { tag: "Enterprise" },
-            },
-            {
               id: "reference/sql/acl/alter-user",
               type: "doc",
               customProps: { tag: "Enterprise" },
             },
+            "reference/sql/asof-join",
             {
               id: "reference/sql/acl/assume-service-account",
               type: "doc",


### PR DESCRIPTION
Create a new page for ASOF JOIN for better indexing and interlinking.

The prior JOIN section routes to ASOF JOIN, while the new page connects to its relatives.