### PR TITLE
sqlalchemy: commit after insert

### DIFF
--- a/third-party-tools/sqlalchemy.md
+++ b/third-party-tools/sqlalchemy.md
@@ -54,6 +54,7 @@ with engine.connect() as conn:
       text("INSERT INTO some_table (x, y) VALUES (:x, :y)"),
       [{"x": 11, "y": 12}, {"x": 13, "y": 14}],
       )
+  conn.commit()
 
   # basic select, no parameters
   result = conn.execute(text("select * from some_table"))


### PR DESCRIPTION
questdb-connect uses psycopg2 under the hood and transaction must be committed explicitly. without this change the SELECT does not see previous INSERT.