### PR TITLE
Fix incorrect `INTEGER` type in `ALTER TABLE COLUMN TYPE` example

### DIFF
--- a/reference/sql/alter-table-change-column-type.md
+++ b/reference/sql/alter-table-change-column-type.md
@@ -32,10 +32,10 @@ compatible data type.
 
 ## Examples
 
-Change the data type of the column `age` in the table `employees` to `INTEGER`:
+Change the data type of the column `age` in the table `employees` to `INT`:
 
 ```questdb-sql
-ALTER TABLE employees ALTER COLUMN age TYPE INTEGER;
+ALTER TABLE employees ALTER COLUMN age TYPE INT;
 ```
 
 When changing the column type, ensure that the new type is compatible with the


### PR DESCRIPTION
Fixes https://github.com/questdb/documentation/issues/54.

![image](https://github.com/user-attachments/assets/5d9362ac-8a8f-4caf-b208-9235fac75bc0)
