### PR TITLE
Fix typo in quick-start

### DIFF
--- a/documentation/quick-start.mdx
+++ b/documentation/quick-start.mdx
@@ -47,7 +47,7 @@ Choose from the following options:
 
 ### Docker
 
-To use Docker, one must have Docker. You can installation find guides for your
+To use Docker, one must have Docker. You can find installation guides for your
 platform on the [official documentation](https://docs.docker.com/get-docker/).
 
 Once Docker is installed, you will need to pull QuestDB's image from


### PR DESCRIPTION
`find installation` instead of `installation find`