### PR TITLE
Fix field name in create-database guide CREATE stmt

### DIFF
--- a/documentation/guides/create-database.md
+++ b/documentation/guides/create-database.md
@@ -54,7 +54,7 @@ CREATE TABLE trades (
     side SYMBOL,
     price DOUBLE,
     amount DOUBLE
-) TIMESTAMP(ts) PARTITION BY DAY WAL
+) TIMESTAMP(timestamp) PARTITION BY DAY WAL
 DEDUP UPSERT KEYS(timestamp, symbol);
 ```
 


### PR DESCRIPTION
Without this patch query fails with "invalid designated timestamp column [name=ts]"