### PR TITLE
prevent posthog error during development

### DIFF
--- a/src/theme/CodeBlock/CopyButton/index.tsx
+++ b/src/theme/CodeBlock/CopyButton/index.tsx
@@ -15,7 +15,9 @@ export default function CopyButton({ code, className }: Props): JSX.Element {
   const handleCopyCode = useCallback(() => {
     copy(code)
     setIsCopied(true)
-    window.posthog.capture("snippet_copied")
+    if (window.posthog) {
+      window.posthog.capture("snippet_copied")
+    }
     copyTimeout.current = window.setTimeout(() => {
       setIsCopied(false)
     }, 1000)


### PR DESCRIPTION
During development Posthog is not enabled and any attempt to use the 'code snippet copy' ends with an annoying error:

![Screenshot From 2025-05-07 12-00-54](https://github.com/user-attachments/assets/9228bf78-34b0-4587-b95d-1f778defe00b)

=> 

![Screenshot From 2025-05-07 11-59-42](https://github.com/user-attachments/assets/39c2225e-db28-48a0-881b-4144aa653edc)



This is annoying when validating code snippets work. This change prevents the error.