### PR TITLE
cross-links pgwire guides

### DIFF
--- a/documentation/concept/geohashes.md
+++ b/documentation/concept/geohashes.md
@@ -490,9 +490,9 @@ geohashes in text mode (i.e. as strings) as opposed to binary
 
 The Python example below demonstrates how to connect to QuestDB over postgres
 wire, insert and query geohashes. It uses the
-[psychopg3](https://www.psycopg.org/psycopg3/docs/) adapter.
+[psycopg3](https://www.psycopg.org/psycopg3/docs/) adapter.
 
-To install `psychopg3`, use `pip`:
+To install `psycopg3`, use `pip`:
 
 ```shell
 python3 -m pip install "psycopg[binary]"

--- a/documentation/partials/_python.sql.insert.partial.mdx
+++ b/documentation/partials/_python.sql.insert.partial.mdx
@@ -1,4 +1,4 @@
-This example uses the [psychopg3](https://www.psycopg.org/psycopg3/docs/)
+This example uses the [psycopg3](https://www.psycopg.org/psycopg3/docs/)
 adapter.
 
 To [install](https://www.psycopg.org/psycopg3/docs/basic/install.html) the

--- a/documentation/reference/api/postgres.md
+++ b/documentation/reference/api/postgres.md
@@ -14,7 +14,7 @@ import RustInsertPartial from "../../partials/_rust.sql.insert.partial.mdx"
 
 QuestDB supports the Postgres Wire Protocol (PGWire) for data-in.
 
-For querying and data-out, QuestDB is compatible with PostgreSQL queries.
+For querying and data-out, QuestDB is compatible with PostgreSQL protocol.
 
 This means that you can use your favorite PostgreSQL client or driver with
 QuestDB.
@@ -26,7 +26,7 @@ For information querying and data-out, see the
 
 The PostgreSQL storage model is fundamentally different than that of QuestDB.
 
-As a result, some features that exists for Postgres do not exist in QuestDB.
+As a result, some features that exists for PostgreSQL do not exist in QuestDB.
 
 :::
 
@@ -106,34 +106,4 @@ For full query details and examples, see the PostgreSQL section in the
 
 ## Recommended third party tools
 
-The following list of third party tools includes drivers, clients or utility
-CLIs that our team has tested extensively. Picking an item from it will
-guarantee that your code will work with QuestDB.
-
-We recognize that our community might value some features more than others. This
-is why we encourage you to [open an issue on GitHub](https://github.com/questdb/questdb/issues) if
-you think we are missing something important for your workflow.
-
-### CLIs
-
-#### [PSQL](https://www.postgresql.org/docs/current/app-psql.html) `12`
-
-Support for `SELECT`, `INSERT`, `UPDATE`, `CREATE`, `DROP`, `TRUNCATE`.
-
-### Libraries / Programmatic clients
-
-#### [node-postgres](https://node-postgres.com/) (NodeJS) `8.4`
-
-#### [pq](https://github.com/lib/pq) (Go) `1.8`
-
-#### [pq](https://www.postgresql.org/docs/12/libpq.html) (C) `12`
-
-#### [Psycopg](https://www.psycopg.org) (Python) `2.9.3` and `3.1`
-
-#### [ruby-pg](https://github.com/ged/ruby-pg) (Ruby) `1.4.3`
-
-#### [pg_connect](https://www.php.net/manual/en/function.pg-connect.php) (PHP) `8.1.0`
-
-### Drivers
-
-#### [JDBC](https://jdbc.postgresql.org/) `42.2`
+See [PGWire client guides](/docs/pgwire/pgwire-intro/) for more information about supported PostgreSQL clients and libraries.

--- a/documentation/reference/api/postgres.md
+++ b/documentation/reference/api/postgres.md
@@ -80,12 +80,11 @@ For full query details and examples, see the PostgreSQL section in the
 ### List of supported features
 
 - Querying (all types expect `BLOB`)
-- Prepared statements with bind parameters (check for specific libraries
-  [below](/docs/reference/api/postgres/#libraries--programmatic-clients))
+- Prepared statements with bind parameters
 - `INSERT` statements with bind parameters
 - `UPDATE` statements with bind parameters
 - DDL execution
-- Batch inserts with `JDBC`
+- Batch inserts
 - Plain authentication
 
 ### List of supported connection properties

--- a/documentation/reference/sql/overview.md
+++ b/documentation/reference/sql/overview.md
@@ -142,29 +142,10 @@ Brief examples in multiple languages are shown below.
 </Tabs>
 
 
-#### Forward-only cursors
+#### Further Reading
 
-QuestDB diverges from PostgreSQL in its handling of
-[cursor commands](https://www.postgresql.org/docs/current/plpgsql-cursors.html).
-While PostgreSQL supports scrollable cursors, enabling backward and forward
-navigation through the results of a SQL query, QuestDB applies a different
-approach.
-
-QuestDB does not support scrollable cursors that require explicit creation and
-management through `DECLARE CURSOR` and subsequent operations like `FETCH`.
-Instead, QuestDB supports non-scrollable, or "forward-only", cursors. This
-distinction means that while you can iterate over query results sequentially,
-you cannot navigate backwards or access result positions as you might with
-scrollable cursors in PostgreSQL.
-
-As a result, some PostgreSQL drivers and libraries that rely on scrollable
-cursors may not be fully compatible with QuestDB. For instance,
-[psycopg2](https://pypi.org/project/psycopg2/) — a popular PostgreSQL driver for
-Python — utilizes scrollable cursors extensively. If possible, select drivers
-that support non-scrollable cursors for optimal compatibility. One such example
-is
-[asyncpg](https://magicstack.github.io/asyncpg/current/api/index.html#cursors),
-which is database driver for asyncio and PostgreSQL.
+See the [PGWire Client overview](/docs/pgwire/pgwire-intro/) for more details on how to use PostgreSQL
+clients to connect to QuestDB.
 
 ## REST HTTP API
 


### PR DESCRIPTION
also:
1. removed dups/outdated info
2. typos (psychopg -> psycopg)