### PR TITLE
adding naming rules for tables and columns

### DIFF
--- a/documentation/ingestion-overview.md
+++ b/documentation/ingestion-overview.md
@@ -48,7 +48,8 @@ trades,symbol=BTC-USD,side=sell price=39269.98,amount=0.001 1646762637710419000\
 trades,symbol=ETH-USD,side=buy price=2615.4,amount=0.002 1646762637764098000\n
 ```
 
-Once inside of QuestDB, it's yours to manipulate and query via extended SQL.
+Once inside of QuestDB, it's yours to manipulate and query via extended SQL. Please note that table and column names
+must follow the QuestDB [naming rules](/docs/reference/sql/create-table/#table-name).
 
 ## Message brokers and queues
 

--- a/documentation/reference/api/ilp/overview.md
+++ b/documentation/reference/api/ilp/overview.md
@@ -389,7 +389,8 @@ For example, the Python client would be configured as outlined in the
 
 When sending data to a table that does not exist, the server will create the
 table automatically. This also applies to columns that do not exist. The server
-will use the first row of data to determine the column types.
+will use the first row of data to determine the column types.  Please note that table
+and column names must follow the QuestDB [naming rules](/docs/reference/sql/create-table/#table-name).
 
 If the table already exists, the server will validate that the columns match the
 existing table. If the columns do not match, the server will return a

--- a/documentation/reference/sql/create-table.md
+++ b/documentation/reference/sql/create-table.md
@@ -271,6 +271,15 @@ Internally the table name is used as a directory name on the file system. It can
 contain both ASCII and Unicode characters. The table name **must be unique** and
 an error is returned if a table already exists with the requested name.
 
+Validation rules:
+- Length: subject to filesystem limits (typically ≤255).
+- Spaces: **not** allowed at the start or end.
+- Period `.`: only a **single** dot is allowed **not** at the start or end and **not** next to another dot.
+- Disallowed characters: `?`, `,`, `'`, `"`, `\`, `/`, `:`, `)`, `(`, `+`, `*`, `%`, `~`, `\u0000`, `\u0001`,
+`\u0002`, `\u0003`, `\u0004`, `\u0005`, `\u0006`, `\u0007`, `\u0008`, `\t`, `\u000B`, `\u000c`, `\r`, `\n`,
+`\u000e`, `\u000f`, `\u007f`, `0xfeff` (UTF-8 BOM).
+
+
 In addition, table names are case insensitive: `example`, `exAmPlE`, `EXAMplE`
 and `EXAMPLE` are all treated the same. Table names containing spaces or period
 `.` character must be enclosed in **double quotes**, for example:
@@ -290,6 +299,14 @@ Tables may have up to **2,147,483,647** columns. Column names are also case
 insensitive. For example: `example`, `exAmPlE`, `EXAMplE` and `EXAMPLE` are all
 treated the same. However, column names **must be** unique within each table and
 **must not contain** a period `.` character.
+
+Validation rules:
+  - Length: subject to filesystem limits (typically ≤255).
+	-	Period `.` : not allowed.
+	-	Hyphen `-`: not allowed.
+	-	Other disallowed characters: `?`, `.`, `,`, `'`, `"`, `\`, `/`, `:`, `)`, `(`, `+`, `-`, `*`, `%`, `~`,
+  `\u0000`, `\u0001`, `\u0002`, `\u0003`, `\u0004`, `\u0005`, `\u0006`, `\u0007`, `\u0008`, `\t`, `\u000B`,
+  `\u000c`, `\n`, `\r`, `\u000e`, `\u000f`, `\u007f`, `0xfeff` (UTF-8 BOM).
 
 ## Type definition
 


### PR DESCRIPTION
Adding all the invalid characters to the table/column creation docs. Adding links from ILP pointing to these rules