### PR TITLE
Fix broken contact link on migrate-to-enterprise page

### DIFF
--- a/documentation/operations/migrate-to-enterprise.md
+++ b/documentation/operations/migrate-to-enterprise.md
@@ -110,4 +110,4 @@ this reason:
 - If reusing an object store from a test Enterprise instance, clear it first
 
 Have a complex migration scenario?
-[Contact us](https://questdb.com/contact/) and we'll help with your setup.
+[Contact us](https://questdb.com/enterprise/contact/) and we'll help with your setup.


### PR DESCRIPTION
## Summary
- Fixed broken `/contact` link on the "Upgrade to QuestDB Enterprise" documentation page
- Updated URL from `https://questdb.com/contact/` to `https://questdb.com/enterprise/contact/`

## Test plan
- [x] Verify the link works correctly on the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)