### PR TITLE
Convert localhost URLs to non-clickable code formatting

### DIFF
--- a/documentation/deployment/docker.md
+++ b/documentation/deployment/docker.md
@@ -212,7 +212,7 @@ http.bind.to=0.0.0.0:4000
 Running the container with the `-v` flag allows for mounting the current
 directory to QuestDB's `conf` directory in the container. With the server
 configuration above, HTTP ports for the [Web Console](/docs/getting-started/web-console/overview/) and REST API will be
-available on http://localhost:4000:
+available on `http://localhost:4000`:
 
 ```bash
 docker run -v "$(pwd):/var/lib/questdb/conf" -p 4000:4000 questdb/questdb

--- a/documentation/getting-started/create-database.md
+++ b/documentation/getting-started/create-database.md
@@ -28,7 +28,7 @@ All that said, in this tutorial you will learn how to:
 ### Before we begin...
 
 All commands are run through the [Web Console](/docs/getting-started/web-console/overview/) accessible at
-http://localhost:9000.
+`http://localhost:9000`.
 
 You can also run the same SQL via the
 [Postgres endpoint](/docs/query/pgwire/overview/) or the

--- a/documentation/getting-started/enterprise-quick-start.md
+++ b/documentation/getting-started/enterprise-quick-start.md
@@ -92,7 +92,7 @@ tls.private.key.path=/path/to/private_key
 
 To hot-reload the certificate and private key and update the files on disk,
 login to your QuestDB [Web Console](/docs/getting-started/web-console/overview/). This is accessible by default at
-http://localhost:9000. Login using the built-in administrator
+`http://localhost:9000`. Login using the built-in administrator
 credential.
 
 Then, execute:

--- a/documentation/getting-started/quick-start.mdx
+++ b/documentation/getting-started/quick-start.mdx
@@ -231,7 +231,7 @@ questdb.exe [start|stop|status|install|remove] \
 
 ## Verify installation
 
-Open [http://localhost:9000](http://localhost:9000) in your browser.
+Open `http://localhost:9000` in your browser.
 
 You should see the QuestDB [Web Console](/docs/getting-started/web-console/overview/).
 

--- a/documentation/getting-started/web-console/overview.md
+++ b/documentation/getting-started/web-console/overview.md
@@ -18,7 +18,7 @@ provides UI tools to query and explore the data, visualize the results in a tabl
 ### Accessing the Web Console
 
 Web Console will be available at `http://[server-address]:9000`. When
-running locally, this will be http://localhost:9000.
+running locally, this will be `http://localhost:9000`.
 
 ### Layout
 

--- a/documentation/ingestion/message-brokers/flink.md
+++ b/documentation/ingestion/message-brokers/flink.md
@@ -97,7 +97,7 @@ Flink. The overall steps are the followings:
   This command used Flink SQL to insert a row into the `Orders` table in Flink.
   The table is connected to QuestDB, so the row is also into QuestDB.
 
-- Go to the QuestDB [Web Console](/docs/getting-started/web-console/overview/) at http://localhost:9000
+- Go to the QuestDB [Web Console](/docs/getting-started/web-console/overview/) at `http://localhost:9000`
   and execute this query:
 
   ```questdb-sql

--- a/documentation/ingestion/message-brokers/redpanda.md
+++ b/documentation/ingestion/message-brokers/redpanda.md
@@ -206,7 +206,7 @@ Now the Kafka Connect is initiated.
 
 ### Send a message
 
-Open the [Redpanda UI topic page](http://127.0.0.1:8080/topics). It should
+Open the Redpanda UI topic page at `http://127.0.0.1:8080/topics`. It should
 display `example-topic`:
 
 ![Screenshot of the Redpanda UI showing the example-topic](/images/docs/guide/redpanda/redpanda-topic.webp)
@@ -230,7 +230,7 @@ Then, click 'Publish'.
 
 ### See result from QuestDB
 
-Go to QuestDB web console at http://localhost:9000. Run
+Go to QuestDB web console at `http://localhost:9000`. Run
 a `SELECT` query:
 
 ```questdb-sql
@@ -326,7 +326,7 @@ The command above sends two JSON messages to Redpanda Connect standard input, wh
 
 ### Verify the integration
 
-Navigate to the QuestDB Web Console at http://localhost:9000 and run the following query to see your data:
+Navigate to the QuestDB Web Console at `http://localhost:9000` and run the following query to see your data:
 
 ```sql
 SELECT *

--- a/documentation/integrations/data-processing/spark.md
+++ b/documentation/integrations/data-processing/spark.md
@@ -105,7 +105,7 @@ Protocol endpoints. The former is required for opening the Web Console, and the
 latter is used by Spark to connect to the database.
 
 Open the [Web Console](/docs/getting-started/web-console/overview/) in your browser at
-http://localhost:9000.
+`http://localhost:9000`.
 
 Run the following SQL commands using the console:
 

--- a/documentation/integrations/orchestration/airflow.md
+++ b/documentation/integrations/orchestration/airflow.md
@@ -76,7 +76,7 @@ cleanup_task = PostgresOperator(
 
 ## Running the Airflow DAG
 
-1. Open the Airflow UI at http://localhost:8080.
+1. Open the Airflow UI at `http://localhost:8080`.
 2. Enable and trigger the `questdb_cleanup` DAG manually.
 
 

--- a/documentation/integrations/orchestration/dagster.md
+++ b/documentation/integrations/orchestration/dagster.md
@@ -57,7 +57,7 @@ def questdb_cleanup_job():
    ```bash
    dagster dev
    ```
-2. Open http://localhost:3000 and trigger the `questdb_cleanup_job` manually.
+2. Open `http://localhost:3000` and trigger the `questdb_cleanup_job` manually.
 
 ## Scheduling the Job
 

--- a/documentation/integrations/other/cube.md
+++ b/documentation/integrations/other/cube.md
@@ -90,8 +90,8 @@ docker-compose up -d
 
 Both applications are now up and ready.
 
-- QuestDB: http://localhost:9000
-- Cube: http://localhost:4000
+- QuestDB: `http://localhost:9000`
+- Cube: `http://localhost:4000`
 
 Not sure what to do next? Check out
 [our tutorial](/blog/2022/04/26/time-series-data-analytics-with-questdb-and-cube/)

--- a/documentation/integrations/other/databento.md
+++ b/documentation/integrations/other/databento.md
@@ -74,7 +74,7 @@ sender.flush()
 
 ## Query QuestDB
 
-Now that data is flowing, you can visit QuestDB at http://localhost:9000 to try some queries.
+Now that data is flowing, you can visit QuestDB at `http://localhost:9000` to try some queries.
 
 Read our [SQL Overview](/docs/query/overview/) to learn more about the power and depth of querying.
 

--- a/documentation/integrations/other/mindsdb.md
+++ b/documentation/integrations/other/mindsdb.md
@@ -24,7 +24,7 @@ data from MindsDB to produce powerful ML models.
 - [docker](https://docs.docker.com/): To create an image and run the container.
 - mysql: The client we use to interact with MindsDB
   (`mysql -h 127.0.0.1 --port 47335 -u mindsdb -p`). Alternatively, use MindsDB
-  web console at http://localhost:47334 instead.
+  web console at `http://localhost:47334` instead.
 - [Curl](https://curl.se/download.html): To upload data to QuestDB from a local
   CSV file.
 
@@ -109,7 +109,7 @@ There are different ways to [insert data to QuestDB](/docs/ingestion/overview/).
 #### SQL
 
 We can access QuestDB's [Web Console](/docs/getting-started/web-console/overview/) at
-http://localhost:9000.
+`http://localhost:9000`.
 
 Run the following SQL query to create a simple table:
 
@@ -173,7 +173,7 @@ mysql -h 127.0.0.1 --port 47335 -u mindsdb -p
 ```
 
 Alternatively, we can use MindsDB web console at
-http://localhost:47334:
+`http://localhost:47334`:
 
 From the terminal or the MindsDB web console, run the following command to check
 the available databases:
@@ -271,7 +271,7 @@ The result should be something like this:
 
 Beyond SELECT statements, for instance when we need to save the results of a
 query into a new table, we need to use QuestDB's [Web Console](/docs/getting-started/web-console/overview/) available at
-http://localhost:9000:
+`http://localhost:9000`:
 
 ```questdb-sql
 CREATE TABLE sample_query_results AS (

--- a/documentation/integrations/visualization/grafana.md
+++ b/documentation/integrations/visualization/grafana.md
@@ -37,7 +37,7 @@ grafana/grafana-oss
 ```
 
 Once the Grafana server has started, you can access it via port 3000
-(http://localhost:3000). The default login credentials
+(`http://localhost:3000`). The default login credentials
 are as follows:
 
 ```shell
@@ -61,7 +61,7 @@ questdb/questdb:latest
 ## Add a data source
 
 1. Open Grafana's UI (by default available at
-   http://localhost:3000)
+   `http://localhost:3000`)
 2. Navigate to the bottom of the page and click **Find more data source
    plugins**.
 3. Search for QuestDB and click **Install**.

--- a/documentation/integrations/visualization/superset.md
+++ b/documentation/integrations/visualization/superset.md
@@ -79,7 +79,7 @@ pip install 'questdb-connect==1.1.3'
 ## Connecting QuestDB to Superset
 
 Once installed and initialized, Apache Superset is accessible via
-http://localhost:8088.
+`http://localhost:8088`.
 
 1. Sign in with the following details:
    - Username: admin

--- a/documentation/query/overview.md
+++ b/documentation/query/overview.md
@@ -63,7 +63,7 @@ libraries like [Polars](/docs/integrations/data-processing/polars/).
 ## QuestDB Web Console
 
 The Web Console is available by default at
-http://localhost:9000. The GUI makes it easy to write, return
+`http://localhost:9000`. The GUI makes it easy to write, return
 and chart queries. There is autocomplete, syntax highlighting, errors, and more.
 If you want to test a query or interact direclty with your data in the cleanest
 and simplest way, apply queries via the [Web Console](/docs/getting-started/web-console/overview/).

--- a/documentation/security/oidc.mdx
+++ b/documentation/security/oidc.mdx
@@ -1058,7 +1058,7 @@ QuestDB requires a mapping, as laid out in the
 If a given user has the HTTP permission, they will be able to now login via the
 [Web Console](/docs/getting-started/web-console/overview/).
 
-To test, head to [http://localhost:9000](http://localhost:9000) and login.
+To test, head to `http://localhost:9000` and login.
 
 If all has been wired up well, then login will succeed.
 

--- a/documentation/tutorials/influxdb-migration.md
+++ b/documentation/tutorials/influxdb-migration.md
@@ -53,11 +53,11 @@ Therefore the example below provides trivialized write examples.
 ### Switch client URLs
 
 By default, the InfluxDB connection string of
-http://localhost:8086 is included in client examples.
+`http://localhost:8086` is included in client examples.
 
 With QuestDB, change `url` in the client method to an active QuestDB instance.
 
-The default QuestDB endpoint is: http://localhost:9000.
+The default QuestDB endpoint is: `http://localhost:9000`.
 
 If you would prefer to use `8086` or any port, alter the HTTP port via
 `http.bind.to` in `server.conf`:


### PR DESCRIPTION
## Summary

- Wrap `localhost` and `127.0.0.1` URLs in prose text with backticks to prevent them from being rendered as clickable hyperlinks
- URLs inside code blocks (curl commands, Python/Go/Node.js examples) are left unchanged as they are part of executable code
- Covers 18 documentation files across getting-started guides, integration docs, message broker tutorials, and API reference

## Files Changed

| Category | Files |
|----------|-------|
| Getting Started | `quick-start.mdx`, `create-database.md`, `enterprise-quick-start.md`, `web-console/overview.md` |
| Integrations | `grafana.md`, `superset.md`, `spark.md`, `cube.md`, `databento.md`, `mindsdb.md`, `airflow.md`, `dagster.md` |
| Message Brokers | `flink.md`, `redpanda.md` |
| Other | `docker.md`, `overview.md`, `oidc.mdx`, `influxdb-migration.md` |

## Test plan

- [x] Verify documentation builds without errors
- [x] Check that localhost URLs render as inline code (non-clickable) in the browser
- [x] Confirm code block examples still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)