### PR TITLE
Add public beta notice to WINDOW JOIN documentation

### DIFF
--- a/documentation/query/sql/window-join.md
+++ b/documentation/query/sql/window-join.md
@@ -6,6 +6,12 @@ description:
   related tables in QuestDB.
 ---
 
+:::info[Public Beta]
+
+WINDOW JOIN is currently in **public beta**. The feature is available for testing and feedback. Syntax or behavior may change in future releases.
+
+:::
+
 WINDOW JOIN is a SQL join type that efficiently aggregates data from a related
 table within a time-based window around each row. It is particularly useful for
 financial time-series analysis, such as calculating rolling statistics from


### PR DESCRIPTION
## Summary

- Adds a prominent info admonition at the top of the WINDOW JOIN documentation page
- Clearly indicates that WINDOW JOIN is currently in **public beta**
- Notifies users that syntax or behavior may change in future releases

## Test plan

- [ ] Verify the admonition renders correctly on the documentation page
- [ ] Confirm the notice is visible and prominent

🤖 Generated with [Claude Code](https://claude.com/claude-code)