### PR TITLE
fix(flink): remove broken Maven badge link

### DIFF
--- a/documentation/ingestion/message-brokers/flink.md
+++ b/documentation/ingestion/message-brokers/flink.md
@@ -159,9 +159,6 @@ and it's available under the following coordinates:
 </dependency>
 ```
 
-The latest version is:
-[![a badge with the latest connector version in Maven Central](https://maven-badges.herokuapp.com/maven-central/org.questdb/flink-questdb-connector/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.questdb/flink-questdb-connector)
-
 ## FAQ
 
 Q: Why is QuestDB client not repackaged into a different Java package?<br/> A:


### PR DESCRIPTION
## Summary
- Removed broken Maven badge link from Flink connector documentation
- The badge was displaying the latest connector version but the link to maven-badges.herokuapp.com was broken

## Test plan
- [x] Verify the Flink connector documentation page renders correctly without the badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)