### PR TITLE
docs(aggregation): add arg_min/arg_max and restructure page

### DIFF
--- a/documentation/query/functions/aggregation.md
+++ b/documentation/query/functions/aggregation.md
@@ -89,42 +89,9 @@ calculations. Functions are organized by category below.
 
 ---
 
-## Usage notes
-
-:::note Implicit GROUP BY
-
-QuestDB supports implicit `GROUP BY`. When you use aggregate functions alongside
-non-aggregated columns, QuestDB automatically groups by the non-aggregated
-columns. These two queries are equivalent:
-
-```questdb-sql
--- Explicit GROUP BY (standard SQL)
-SELECT symbol, avg(price) FROM trades GROUP BY symbol;
-
--- Implicit GROUP BY (QuestDB shorthand)
-SELECT symbol, avg(price) FROM trades;
-```
-
-Examples in this documentation often use implicit `GROUP BY` for brevity.
-
-:::
-
-:::note NULL value handling
-
-Most aggregate functions ignore `NULL` values during computation. For example,
-`sum(column)` adds only non-NULL values, and `avg(column)` calculates the mean
-of non-NULL values only.
-
-Exceptions and special cases:
-- `count(*)` counts all rows including those with NULL values
-- `count(column)` counts only non-NULL values in the specified column
-- `first()` and `last()` may return NULL if the first/last row contains NULL
-- `first_not_null()` and `last_not_null()` skip NULL values
-
-For functions with multiple arguments (like `arg_min`, `arg_max`), NULL handling
-is documented in each function's description.
-
-:::
+QuestDB supports implicit `GROUP BY`. When aggregate functions are used with
+non-aggregated columns, QuestDB automatically groups by those columns. Examples
+in this documentation often omit `GROUP BY` for brevity.
 
 ---
 


### PR DESCRIPTION
## Summary

Major restructure and expansion of the aggregation functions documentation page.

## Changes

### New function documentation
- **arg_min / arg_max** - Complete documentation including parameters, return types, supported type combinations, null handling, and examples
- **bit_and / bit_or / bit_xor** - Bitwise aggregate functions
- **bool_and / bool_or** - Boolean aggregate functions
- **geomean** - Geometric mean function

### Page restructure
- **Function categories table** - Groups 30+ aggregate functions into logical categories (Basic, Positional, Statistical, Approximate, String, Boolean, Bitwise, Specialized)
- **Implicit GROUP BY note** - Brief explanation of QuestDB's implicit grouping behavior
- **"See also" sections** - Cross-references between related functions (e.g., arg_max ↔ max ↔ last)

### Bug fixes
- Fixed typo: `timestmap` → `timestamp`
- Fixed 6 incorrect table headers: `stddev_samp` → `stddev_pop`, `stddev_samp` → `var_samp`, `stddev_samp` → `var_pop`, `amount` → `max`, `count` → `sum`, `avg` → `corr`
- Fixed SQL syntax errors: `FROM table rides` → `FROM rides;`, `FROM table` → `FROM my_table`
- Fixed outdated comment: "sky cover types observed in the weather table" → "symbols observed in the trades table"
- Removed outdated note claiming nested aggregates are not supported (they now work)
- Cleaned up inconsistent blank lines throughout

## Test plan

- [x] Verify page renders correctly in local preview
- [x] Check all internal anchor links work correctly
- [x] Verify function category table links navigate to correct sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)