### PR TITLE
Document secrets from files for Kubernetes deployments

### DIFF
--- a/documentation/getting-started/enterprise-quick-start.md
+++ b/documentation/getting-started/enterprise-quick-start.md
@@ -74,6 +74,15 @@ acl.admin.user=myadmin
 acl.admin.password=my_very_secure_pwd
 ```
 
+:::tip Kubernetes deployments
+
+In Kubernetes, you can read the password from a mounted secret file instead of
+hardcoding it. Set `QDB_ACL_ADMIN_PASSWORD_FILE` to the path of the mounted
+secret. See [Secrets from files](/docs/configuration/overview/#secrets-from-files)
+for details.
+
+:::
+
 We will optionally disable this built-in administrator account later.
 
 For more on access control, see [Role-Based Access Control](/docs/security/rbac/).


### PR DESCRIPTION
## Summary

Documents the `_FILE` suffix convention for reading sensitive configuration values from mounted files, enabling native integration with Kubernetes Secrets.

Related to:
- https://github.com/questdb/questdb/pull/6719 (OSS)
- https://github.com/questdb/questdb-enterprise/pull/882 (Enterprise)

## Changes

- **Configuration overview**: Add "Secrets from files" section covering:
  - Usage with environment variables and properties
  - Precedence rules (`_FILE` takes priority over direct values)
  - File requirements (64KB max, UTF-8, path restrictions)
  - Error handling (startup vs runtime behavior)
  - Reloading with `reload_config()`
  - Supported properties (OSS and Enterprise separated)

- **Kubernetes page**: Add "Using Kubernetes secrets" section with:
  - Complete StatefulSet + Secret YAML example
  - Note about production deployments using Helm chart

- **Enterprise quick start**: Add tip for Kubernetes password configuration

## Test plan

- [x] Preview configuration overview: `/docs/configuration/overview/#secrets-from-files`
- [x] Preview Kubernetes page: `/docs/deployment/kubernetes/#using-kubernetes-secrets`
- [x] Preview Enterprise quick start: `/docs/getting-started/enterprise-quick-start/#0-secure-the-built-in-admin`
- [x] Verify all internal links work

🤖 Generated with [Claude Code](https://claude.ai/code)