### PR TITLE
Document count(distinct) syntax

### DIFF
--- a/documentation/query/functions/aggregation.md
+++ b/documentation/query/functions/aggregation.md
@@ -806,6 +806,13 @@ or `count(distinct column_name)`.
 `count_distinct(column_name)` - counts distinct non-`NULL` values in `varchar`,
 `symbol`, `long256`, `UUID`, `IPv4`, `long`, `int` or `string` columns.
 
+:::tip
+
+`count_distinct` is available for backwards compatibility. We recommend using
+the standard SQL syntax [`count(distinct column_name)`](#count) instead.
+
+:::
+
 #### Return value
 
 Return value type is `long`.


### PR DESCRIPTION
- Add `count(distinct column_name)` syntax to the `count()` section in the aggregation reference
- Note that it is identical to `count_distinct(column_name)`
- Add a usage example and update the NULL-handling note

