### PR TITLE
docs: update SAMPLE BY timezone bucket alignment behavior

### DIFF
--- a/documentation/query/sql/sample-by.md
+++ b/documentation/query/sql/sample-by.md
@@ -214,7 +214,19 @@ This is distinct from the `WHERE` clause with a simple rule of thumb -
 
 Use both `FROM` and `TO` in isolation to pre-fill or post-fill data. If `FROM` is not provided, then the lower bound is the start of the dataset, aligned to calendar. The opposite is true omitting `TO`.
 
-The boundary timestamps are expected in UTC. `FROM-TO` can only be used on non-keyed SAMPLE BY queries (queries with no grouping columns other than the timestamp).
+When used without a `TIME ZONE`, boundary timestamps are interpreted as UTC. When a `TIME ZONE` is specified in `ALIGN TO CALENDAR`, the `FROM` and `TO` values are interpreted as local time in that timezone. For example:
+
+```questdb-sql
+SELECT ts, count()
+FROM trades
+SAMPLE BY 1h FROM '2026-01-01T00:00:00' TO '2026-01-02T00:00:00' FILL(NULL)
+ALIGN TO CALENDAR TIME ZONE 'Europe/Berlin';
+```
+
+Here, `FROM '2026-01-01T00:00:00'` means midnight January 1st in Berlin local time
+(= `2025-12-31T23:00:00Z` UTC).
+
+`FROM-TO` can only be used on non-keyed SAMPLE BY queries (queries with no grouping columns other than the timestamp).
 
 ### `WHERE` clause optimisation
 
@@ -391,16 +403,35 @@ FROM (
 #### Time zone transitions
 
 Calendar dates may contain historical time zone transitions or may vary in the
-total number of hours due to daylight savings time. Considering the 31st October
-2021, in the `Europe/London` calendar day which consists of 25 hours:
+total number of hours due to daylight savings time. How `SAMPLE BY` handles
+DST transitions depends on the stride size.
+
+##### Super-day strides (day, week, month, year)
+
+Super-day strides adjust bucket length to follow the local calendar. For
+example, October 31st 2021 in `Europe/London` is a 25-hour day:
 
 > - Sunday, 31 October 2021, 02:00:00 clocks are turned backward 1 hour to
 > - Sunday, 31 October 2021, 01:00:00 local standard time
 
-When a `SAMPLE BY` operation crosses time zone transitions in cases such as
-this, the first sampled group which spans a transition will include aggregates
-by full calendar range. Consider a table `trades` with one trade per hour
-spanning five calendar hours:
+Given one data point per hour, running `SAMPLE BY 1d` aligned to calendar
+time zone `Europe/London` will produce a count of `25` for this day.
+
+##### Sub-day strides (hours, minutes, seconds)
+
+Sub-day strides use the timezone's standard (non-DST) offset to maintain
+uniform bucket width in UTC. This has the following effects during DST
+transitions:
+
+- **Fall-back** (clocks go back): the repeated local hour produces two separate
+  UTC-based buckets. Both buckets map to the same local time but have distinct
+  UTC timestamps. Output timestamps remain monotonic in UTC.
+- **Spring-forward** (clocks go forward): the skipped local hour produces no
+  bucket if no UTC timestamps fall in that range.
+- Bucket boundaries are evenly spaced in UTC, regardless of DST transitions.
+
+Consider a table `trades` with one trade per hour spanning five calendar hours
+around the `Europe/London` fall-back:
 
 | ts                          | price |
 | --------------------------- | ----- |
@@ -410,8 +441,7 @@ spanning five calendar hours:
 | 2021-10-31T03:10:00.000000Z | 101.5 |
 | 2021-10-31T04:10:00.000000Z | 102.0 |
 
-The following query will sample by hour with the `Europe/London` time zone and
-align to calendar ranges:
+The following query will sample by hour with the `Europe/London` time zone:
 
 ```questdb-sql
 SELECT ts, count()
@@ -420,19 +450,21 @@ SAMPLE BY 1h
 ALIGN TO CALENDAR TIME ZONE 'Europe/London';
 ```
 
-The record count for the hour which encounters a time zone transition will
-contain two records for both hours at the time zone transition:
+Since `Europe/London` has a standard offset of UTC+0, sub-day buckets align
+with UTC hour boundaries. Each data point falls into its own bucket:
 
 | ts                          | count |
 | --------------------------- | ----- |
-| 2021-10-31T00:00:00.000000Z | 2     |
+| 2021-10-31T00:00:00.000000Z | 1     |
 | 2021-10-31T01:00:00.000000Z | 1     |
 | 2021-10-31T02:00:00.000000Z | 1     |
 | 2021-10-31T03:00:00.000000Z | 1     |
+| 2021-10-31T04:00:00.000000Z | 1     |
 
-Similarly, given one data point per hour on this table, running `SAMPLE BY 1d`
-will have a count of `25` for this day when aligned to calendar time zone
-`Europe/London`.
+For timezones with a non-zero standard offset (e.g., `Europe/Berlin` at
+UTC+1), bucket boundaries shift by the standard offset but remain uniformly
+spaced in UTC. During a fall-back transition, data in the repeated local hour
+will be split across two consecutive UTC buckets rather than merged into one.
 
 ### WITH OFFSET
 


### PR DESCRIPTION
## Summary

- **FROM/TO with TIME ZONE**: `FROM` and `TO` boundary timestamps are now interpreted as local time when `TIME ZONE` is specified in `ALIGN TO CALENDAR`, not as UTC. Added example showing the conversion.
- **Sub-day stride DST behavior**: Restructured the "Time zone transitions" section into super-day and sub-day strides. Sub-day strides (hours, minutes, seconds) now use the timezone's standard (non-DST) offset for uniform UTC bucket spacing. During DST fall-back, the repeated local hour produces separate UTC rows instead of being merged.
- **Updated example results**: The hourly `Europe/London` fall-back example now shows 5 rows (each count 1) instead of 4 rows (first with count 2), matching the new uniform UTC bucket behavior.

Reflects breaking change in questdb/questdb#6858.

## Test plan

- [x] `yarn build` passes
- [ ] Verify examples match actual QuestDB output after questdb#6858 is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)