### PR TITLE
Fix alphabetical ordering, add missing functions, correct docs

### DIFF
--- a/documentation/query/functions/aggregation.md
+++ b/documentation/query/functions/aggregation.md
@@ -13,44 +13,44 @@ calculations. Functions are organized by category below.
 
 | Function | Description |
 | :------- | :---------- |
-| [count](#count) | Count rows or non-NULL values |
-| [sum](#sum) | Sum of values |
 | [avg](#avg) | Arithmetic mean |
+| [count](#count) | Count rows or non-NULL values |
 | [geomean](#geomean) | Geometric mean |
-| [min](#min) | Minimum value |
 | [max](#max) | Maximum value |
+| [min](#min) | Minimum value |
+| [sum](#sum) | Sum of values |
 
 ### Positional aggregates
 
 | Function | Description |
 | :------- | :---------- |
+| [arg_max](#arg_max) | Value at the row where another column is maximum |
+| [arg_min](#arg_min) | Value at the row where another column is minimum |
 | [first](#first) | First value (by designated timestamp or insertion order) |
 | [first_not_null](#first_not_null) | First non-NULL value |
 | [last](#last) | Last value (by designated timestamp or insertion order) |
 | [last_not_null](#last_not_null) | Last non-NULL value |
-| [arg_min](#arg_min) | Value at the row where another column is minimum |
-| [arg_max](#arg_max) | Value at the row where another column is maximum |
 
 ### Statistical aggregates
 
 | Function | Description |
 | :------- | :---------- |
-| [stddev / stddev_samp](#stddev--stddev_samp) | Sample standard deviation |
-| [stddev_pop](#stddev_pop) | Population standard deviation |
-| [variance / var_samp](#variance--var_samp) | Sample variance |
-| [var_pop](#var_pop) | Population variance |
 | [corr](#corr) | Pearson correlation coefficient |
 | [covar_pop](#covar_pop) | Population covariance |
 | [covar_samp](#covar_samp) | Sample covariance |
 | [mode](#mode) | Most frequent value |
+| [stddev / stddev_samp](#stddev--stddev_samp) | Sample standard deviation |
+| [stddev_pop](#stddev_pop) | Population standard deviation |
+| [var_pop](#var_pop) | Population variance |
+| [variance / var_samp](#variance--var_samp) | Sample variance |
 
 ### Approximate aggregates
 
 | Function | Description |
 | :------- | :---------- |
 | [approx_count_distinct](#approx_count_distinct) | Estimated distinct count using HyperLogLog |
-| [approx_percentile](#approx_percentile) | Approximate percentile using HdrHistogram |
 | [approx_median](#approx_median) | Approximate median (50th percentile) |
+| [approx_percentile](#approx_percentile) | Approximate percentile using HdrHistogram |
 
 ### String aggregates
 
@@ -58,6 +58,7 @@ calculations. Functions are organized by category below.
 | :------- | :---------- |
 | [string_agg](#string_agg) | Concatenate values with delimiter |
 | [string_distinct_agg](#string_distinct_agg) | Concatenate distinct values with delimiter |
+
 
 ### Boolean aggregates
 
@@ -79,9 +80,9 @@ calculations. Functions are organized by category below.
 | Function | Description |
 | :------- | :---------- |
 | [count_distinct](#count_distinct) | Exact count of distinct values |
+| [haversine_dist_deg](#haversine_dist_deg) | Total traveled distance from lat/lon points |
 | [ksum](#ksum) | Kahan compensated sum (for floating-point precision) |
 | [nsum](#nsum) | Neumaier sum (for floating-point precision) |
-| [haversine_dist_deg](#haversine_dist_deg) | Total traveled distance from lat/lon points |
 | [twap](#twap) | Time-weighted average price |
 | [weighted_avg](#weighted_avg) | Weighted arithmetic mean |
 | [weighted_stddev](#weighted_stddev) | Weighted standard deviation (reliability weights) |

--- a/documentation/query/functions/aggregation.md
+++ b/documentation/query/functions/aggregation.md
@@ -193,46 +193,6 @@ SELECT store_id, approx_count_distinct(transaction_id) FROM transactions GROUP B
 | 2        | 67890                 |
 | ...      | ...                   |
 
-## approx_percentile
-
-`approx_percentile(value, percentile, precision)` calculates the approximate
-value for the given non-negative column and percentile using the
-[HdrHistogram](http://hdrhistogram.org/) algorithm.
-
-#### Parameters
-
-- `value` is any numeric non-negative value.
-- `percentile` is a `double` value between 0.0 and 1.0, inclusive.
-- `precision` is an optional `int` value between 0 and 5, inclusive. This is the
-  number of significant decimal digits to which the histogram will maintain
-  value resolution and separation. For example, when the input column contains
-  integer values between 0 and 3,600,000,000 and the precision is set to 3,
-  value quantization within the range will be no larger than 1/1,000th (or 0.1%)
-  of any value. In this example, the function tracks and analyzes the counts of
-  observed response times ranging between 1 microsecond and 1 hour in magnitude,
-  while maintaining a value resolution of 1 microsecond up to 1 millisecond, a
-  resolution of 1 millisecond (or better) up to one second, and a resolution of
-  1 second (or better) up to 1,000 seconds. At its maximum tracked value (1
-  hour), it would still maintain a resolution of 3.6 seconds (or better).
-
-#### Return value
-
-Return value type is `double`.
-
-#### Examples
-
-```questdb-sql title="Approximate percentile"
-SELECT approx_percentile(price, 0.99) FROM trades;
-```
-
-| approx_percentile |
-| :---------------- |
-| 101.5             |
-
-#### See also
-
-- [approx_median](#approx_median) - Shorthand for 50th percentile
-
 ## approx_median
 
 `approx_median(value, precision)` calculates the approximate median (50th
@@ -283,6 +243,46 @@ GROUP BY symbol;
 #### See also
 
 - [approx_percentile](#approx_percentile) - Approximate percentile for any quantile
+
+## approx_percentile
+
+`approx_percentile(value, percentile, precision)` calculates the approximate
+value for the given non-negative column and percentile using the
+[HdrHistogram](http://hdrhistogram.org/) algorithm.
+
+#### Parameters
+
+- `value` is any numeric non-negative value.
+- `percentile` is a `double` value between 0.0 and 1.0, inclusive.
+- `precision` is an optional `int` value between 0 and 5, inclusive. This is the
+  number of significant decimal digits to which the histogram will maintain
+  value resolution and separation. For example, when the input column contains
+  integer values between 0 and 3,600,000,000 and the precision is set to 3,
+  value quantization within the range will be no larger than 1/1,000th (or 0.1%)
+  of any value. In this example, the function tracks and analyzes the counts of
+  observed response times ranging between 1 microsecond and 1 hour in magnitude,
+  while maintaining a value resolution of 1 microsecond up to 1 millisecond, a
+  resolution of 1 millisecond (or better) up to one second, and a resolution of
+  1 second (or better) up to 1,000 seconds. At its maximum tracked value (1
+  hour), it would still maintain a resolution of 3.6 seconds (or better).
+
+#### Return value
+
+Return value type is `double`.
+
+#### Examples
+
+```questdb-sql title="Approximate percentile"
+SELECT approx_percentile(price, 0.99) FROM trades;
+```
+
+| approx_percentile |
+| :---------------- |
+| 101.5             |
+
+#### See also
+
+- [approx_median](#approx_median) - Shorthand for 50th percentile
 
 ## arg_max
 
@@ -1761,6 +1761,33 @@ SAMPLE BY 1h;
 - [avg](#avg) - Arithmetic mean (equal-weighted)
 - [weighted_avg](#weighted_avg) - Weighted arithmetic mean
 
+## var_pop
+
+`var_pop(value)` - Calculates the population variance of a set of values. The
+population variance is a measure of the amount of variation or dispersion of a
+set of values. A low variance indicates that the values tend to be very close to
+the mean, while a high variance indicates that the values are spread out over a
+wider range.
+
+#### Parameters
+
+- `value` is any numeric value.
+
+#### Return value
+
+Return value type is `double`.
+
+#### Examples
+
+```questdb-sql
+SELECT var_pop(x)
+FROM (SELECT x FROM long_sequence(100));
+```
+
+| var_pop |
+| :------ |
+| 833.25  |
+
 ## variance / var_samp
 
 `var_samp(value)` - Calculates the sample variance of a set of values. The
@@ -1789,33 +1816,6 @@ FROM (SELECT x FROM long_sequence(100));
 | var_samp         |
 | :--------------- |
 | 841.666666666666 |
-
-## var_pop
-
-`var_pop(value)` - Calculates the population variance of a set of values. The
-population variance is a measure of the amount of variation or dispersion of a
-set of values. A low variance indicates that the values tend to be very close to
-the mean, while a high variance indicates that the values are spread out over a
-wider range.
-
-#### Parameters
-
-- `value` is any numeric value.
-
-#### Return value
-
-Return value type is `double`.
-
-#### Examples
-
-```questdb-sql
-SELECT var_pop(x)
-FROM (SELECT x FROM long_sequence(100));
-```
-
-| var_pop |
-| :------ |
-| 833.25  |
 
 ## weighted_avg
 

--- a/documentation/query/functions/array.md
+++ b/documentation/query/functions/array.md
@@ -229,6 +229,116 @@ SELECT array_cum_sum(ARRAY[ [1.0, 1.0], [2.0, 2.0] ]);
 | ---------------------- |
 | ARRAY[1.0,2.0,4.0,6.0] |
 
+## array_elem_avg
+
+`array_elem_avg(array1, array2 [, ...])` or `array_elem_avg(array)` returns an
+array where each element is the average of the corresponding elements across the
+inputs. Works in both
+[multi-argument and aggregate modes](#array_elem_min), with the same NULL handling,
+different-length, and multi-dimensional behavior as `array_elem_min`.
+
+Uses Kahan compensated summation to minimize floating-point rounding errors.
+
+#### Parameters
+
+**Multi-argument mode:**
+
+- `array1`, `array2` [, `...`] — two or more `DOUBLE[]` arrays
+
+**Aggregate mode:**
+
+- `array` — a `DOUBLE[]` column
+
+#### Examples
+
+```questdb-sql
+SELECT array_elem_avg(ARRAY[10.0, 20.0, 30.0], ARRAY[30.0, 40.0, 50.0]);
+```
+
+| array_elem_avg     |
+| ------------------ |
+| [20.0,30.0,40.0]   |
+
+**Aggregate — average bid sizes per symbol each hour:**
+
+```questdb-sql
+CREATE TABLE book_sizes (
+    ts TIMESTAMP, symbol SYMBOL, bid_sizes DOUBLE[]
+) TIMESTAMP(ts) PARTITION BY DAY;
+
+INSERT INTO book_sizes VALUES
+  ('2025-06-01T09:30:00', 'AAPL', ARRAY[100.0, 200.0, 150.0]),
+  ('2025-06-01T09:30:05', 'AAPL', ARRAY[120.0, 180.0, 160.0, 90.0]),
+  ('2025-06-01T09:30:00', 'MSFT', ARRAY[500.0, 400.0]),
+  ('2025-06-01T09:30:05', 'MSFT', ARRAY[600.0, 300.0]);
+
+SELECT ts, symbol, array_elem_avg(bid_sizes)
+FROM book_sizes
+SAMPLE BY 1h;
+```
+
+| ts                          | symbol | array_elem_avg           |
+| --------------------------- | ------ | ------------------------ |
+| 2025-06-01T09:00:00.000000Z | AAPL   | [110.0,190.0,155.0,90.0] |
+| 2025-06-01T09:00:00.000000Z | MSFT   | [550.0,350.0]            |
+
+The `AAPL` group has snapshots with different book depths. The fourth position
+only has one contributing row.
+
+## array_elem_max
+
+`array_elem_max(array1, array2 [, ...])` or `array_elem_max(array)` returns an
+array where each element is the maximum of the corresponding elements across the
+inputs. Works in both
+[multi-argument and aggregate modes](#array_elem_min), with the same NULL handling,
+different-length, and multi-dimensional behavior as `array_elem_min`.
+
+#### Parameters
+
+**Multi-argument mode:**
+
+- `array1`, `array2` [, `...`] — two or more `DOUBLE[]` arrays
+
+**Aggregate mode:**
+
+- `array` — a `DOUBLE[]` column
+
+#### Examples
+
+```questdb-sql
+SELECT array_elem_max(ARRAY[1.0, 5.0, 3.0], ARRAY[4.0, 2.0, 6.0]);
+```
+
+| array_elem_max  |
+| --------------- |
+| [4.0,5.0,6.0]   |
+
+```questdb-sql
+SELECT array_elem_max(
+    ARRAY[[1.0, 8.0, 3.0], [5.0, 2.0, 9.0]],
+    ARRAY[[4.0, 6.0, 7.0], [3.0, 8.0, 1.0]]
+);
+```
+
+| array_elem_max                     |
+| ---------------------------------- |
+| [[4.0,8.0,7.0],[5.0,8.0,9.0]]      |
+
+**Aggregate — best bid prices per symbol each hour:**
+
+Using the `book` table from the [array_elem_min](#array_elem_min) example:
+
+```questdb-sql
+SELECT ts, symbol, array_elem_max(bid_prices)
+FROM book
+SAMPLE BY 1h;
+```
+
+| ts                          | symbol | array_elem_max             |
+| --------------------------- | ------ | -------------------------- |
+| 2025-06-01T09:00:00.000000Z | AAPL   | [150.5,149.5,149.0,148.0]  |
+| 2025-06-01T09:00:00.000000Z | MSFT   | [420.0,419.5]              |
+
 ## array_elem_min
 
 `array_elem_min(array1, array2 [, ...])` or `array_elem_min(array)` returns an
@@ -344,60 +454,6 @@ SELECT array_elem_min(
 | ---------------------------------- |
 | [[1.0,6.0,3.0],[3.0,2.0,1.0]]      |
 
-## array_elem_max
-
-`array_elem_max(array1, array2 [, ...])` or `array_elem_max(array)` returns an
-array where each element is the maximum of the corresponding elements across the
-inputs. Works in both
-[multi-argument and aggregate modes](#array_elem_min), with the same NULL handling,
-different-length, and multi-dimensional behavior as `array_elem_min`.
-
-#### Parameters
-
-**Multi-argument mode:**
-
-- `array1`, `array2` [, `...`] — two or more `DOUBLE[]` arrays
-
-**Aggregate mode:**
-
-- `array` — a `DOUBLE[]` column
-
-#### Examples
-
-```questdb-sql
-SELECT array_elem_max(ARRAY[1.0, 5.0, 3.0], ARRAY[4.0, 2.0, 6.0]);
-```
-
-| array_elem_max  |
-| --------------- |
-| [4.0,5.0,6.0]   |
-
-```questdb-sql
-SELECT array_elem_max(
-    ARRAY[[1.0, 8.0, 3.0], [5.0, 2.0, 9.0]],
-    ARRAY[[4.0, 6.0, 7.0], [3.0, 8.0, 1.0]]
-);
-```
-
-| array_elem_max                     |
-| ---------------------------------- |
-| [[4.0,8.0,7.0],[5.0,8.0,9.0]]      |
-
-**Aggregate — best bid prices per symbol each hour:**
-
-Using the `book` table from the [array_elem_min](#array_elem_min) example:
-
-```questdb-sql
-SELECT ts, symbol, array_elem_max(bid_prices)
-FROM book
-SAMPLE BY 1h;
-```
-
-| ts                          | symbol | array_elem_max             |
-| --------------------------- | ------ | -------------------------- |
-| 2025-06-01T09:00:00.000000Z | AAPL   | [150.5,149.5,149.0,148.0]  |
-| 2025-06-01T09:00:00.000000Z | MSFT   | [420.0,419.5]              |
-
 ## array_elem_sum
 
 `array_elem_sum(array1, array2 [, ...])` or `array_elem_sum(array)` returns an
@@ -449,62 +505,6 @@ SELECT array_elem_sum(fill_qtys) FROM fills;
 | array_elem_sum  |
 | --------------- |
 | [500.0,550.0]   |
-
-## array_elem_avg
-
-`array_elem_avg(array1, array2 [, ...])` or `array_elem_avg(array)` returns an
-array where each element is the average of the corresponding elements across the
-inputs. Works in both
-[multi-argument and aggregate modes](#array_elem_min), with the same NULL handling,
-different-length, and multi-dimensional behavior as `array_elem_min`.
-
-Uses Kahan compensated summation to minimize floating-point rounding errors.
-
-#### Parameters
-
-**Multi-argument mode:**
-
-- `array1`, `array2` [, `...`] — two or more `DOUBLE[]` arrays
-
-**Aggregate mode:**
-
-- `array` — a `DOUBLE[]` column
-
-#### Examples
-
-```questdb-sql
-SELECT array_elem_avg(ARRAY[10.0, 20.0, 30.0], ARRAY[30.0, 40.0, 50.0]);
-```
-
-| array_elem_avg     |
-| ------------------ |
-| [20.0,30.0,40.0]   |
-
-**Aggregate — average bid sizes per symbol each hour:**
-
-```questdb-sql
-CREATE TABLE book_sizes (
-    ts TIMESTAMP, symbol SYMBOL, bid_sizes DOUBLE[]
-) TIMESTAMP(ts) PARTITION BY DAY;
-
-INSERT INTO book_sizes VALUES
-  ('2025-06-01T09:30:00', 'AAPL', ARRAY[100.0, 200.0, 150.0]),
-  ('2025-06-01T09:30:05', 'AAPL', ARRAY[120.0, 180.0, 160.0, 90.0]),
-  ('2025-06-01T09:30:00', 'MSFT', ARRAY[500.0, 400.0]),
-  ('2025-06-01T09:30:05', 'MSFT', ARRAY[600.0, 300.0]);
-
-SELECT ts, symbol, array_elem_avg(bid_sizes)
-FROM book_sizes
-SAMPLE BY 1h;
-```
-
-| ts                          | symbol | array_elem_avg           |
-| --------------------------- | ------ | ------------------------ |
-| 2025-06-01T09:00:00.000000Z | AAPL   | [110.0,190.0,155.0,90.0] |
-| 2025-06-01T09:00:00.000000Z | MSFT   | [550.0,350.0]            |
-
-The `AAPL` group has snapshots with different book depths. The fourth position
-only has one contributing row.
 
 ## array_max
 

--- a/documentation/query/functions/date-time.md
+++ b/documentation/query/functions/date-time.md
@@ -59,9 +59,9 @@ reference for Python, Go, Java, JavaScript, C/C++, Rust, and C#/.NET.
 | :------- | :---------- |
 | [now](#now) | Current timestamp (stable within query) |
 | [now_ns](#now_ns) | Current timestamp with nanosecond precision (stable within query) |
+| [sysdate](#sysdate) | Current date with millisecond precision |
 | [systimestamp](#systimestamp) | Current timestamp (changes per row) |
 | [systimestamp_ns](#systimestamp_ns) | Current timestamp with nanosecond precision (changes per row) |
-| [sysdate](#sysdate) | Current date with millisecond precision |
 | [today](#today-tomorrow-yesterday) | Interval for current day |
 | [tomorrow](#today-tomorrow-yesterday) | Interval for next day |
 | [yesterday](#today-tomorrow-yesterday) | Interval for previous day |
@@ -70,29 +70,29 @@ reference for Python, Go, Java, JavaScript, C/C++, Rust, and C#/.NET.
 
 | Function | Description |
 | :------- | :---------- |
-| [extract](#extract) | Extract any time unit from timestamp |
-| [year](#year) | Extract year from timestamp |
-| [month](#month) | Extract month (1-12) |
 | [day](#day) | Extract day of month (1-31) |
-| [hour](#hour) | Extract hour (0-23) |
-| [minute](#minute) | Extract minute (0-59) |
-| [second](#second) | Extract second (0-59) |
-| [millis](#millis) | Extract milliseconds (0-999) |
-| [micros](#micros) | Extract microseconds (0-999) |
-| [nanos](#nanos) | Extract nanoseconds (0-999) |
 | [day_of_week](#day_of_week) | Day number (1=Monday to 7=Sunday) |
 | [day_of_week_sunday_first](#day_of_week_sunday_first) | Day number (1=Sunday to 7=Saturday) |
 | [days_in_month](#days_in_month) | Number of days in the month |
-| [week_of_year](#week_of_year) | Week number in year |
+| [extract](#extract) | Extract any time unit from timestamp |
+| [hour](#hour) | Extract hour (0-23) |
 | [is_leap_year](#is_leap_year) | Check if year is a leap year |
+| [micros](#micros) | Extract microseconds (0-999) |
+| [millis](#millis) | Extract milliseconds (0-999) |
+| [minute](#minute) | Extract minute (0-59) |
+| [month](#month) | Extract month (1-12) |
+| [nanos](#nanos) | Extract nanoseconds (0-999) |
+| [second](#second) | Extract second (0-59) |
+| [week_of_year](#week_of_year) | Week number in year |
+| [year](#year) | Extract year from timestamp |
 
 ### Arithmetic
 
 | Function | Description |
 | :------- | :---------- |
+| [date_trunc](#date_trunc) | Truncate timestamp to specified precision |
 | [dateadd](#dateadd) | Add time period to timestamp |
 | [datediff](#datediff) | Difference between timestamps |
-| [date_trunc](#date_trunc) | Truncate timestamp to specified precision |
 | [timestamp_ceil](#timestamp_ceil) | Round timestamp up to unit boundary |
 | [timestamp_floor](#timestamp_floor) | Round timestamp down to unit/interval boundary |
 
@@ -100,10 +100,10 @@ reference for Python, Go, Java, JavaScript, C/C++, Rust, and C#/.NET.
 
 | Function | Description |
 | :------- | :---------- |
-| [to_timestamp](#to_timestamp) | Parse string to timestamp (microsecond) |
-| [to_timestamp_ns](#to_timestamp_ns) | Parse string to timestamp (nanosecond) |
 | [to_date](#to_date) | Parse string to date |
 | [to_str](#to_str) | Format timestamp as string |
+| [to_timestamp](#to_timestamp) | Parse string to timestamp (microsecond) |
+| [to_timestamp_ns](#to_timestamp_ns) | Parse string to timestamp (nanosecond) |
 | [to_timezone](#to_timezone) | Convert timestamp to timezone |
 | [to_utc](#to_utc) | Convert timestamp to UTC |
 
@@ -112,15 +112,15 @@ reference for Python, Go, Java, JavaScript, C/C++, Rust, and C#/.NET.
 | Function | Description |
 | :------- | :---------- |
 | [interval](#interval) | Create interval from two timestamps |
-| [interval_start](#interval_start) | Extract interval lower bound |
 | [interval_end](#interval_end) | Extract interval upper bound |
+| [interval_start](#interval_start) | Extract interval lower bound |
 
 ### Utilities
 
 | Function | Description |
 | :------- | :---------- |
-| [timestamp_shuffle](#timestamp_shuffle) | Generate random timestamp in range |
 | [pg_postmaster_start_time](#pg_postmaster_start_time) | Server start time (PostgreSQL compatibility) |
+| [timestamp_shuffle](#timestamp_shuffle) | Generate random timestamp in range |
 
 ---
 
@@ -582,33 +582,6 @@ SELECT interval('2024-10-08T11:09:47.573Z', '2024-10-09T11:09:47.573Z')
 - [interval_end](#interval_end) - Extract interval upper bound
 - [TICK syntax](/docs/query/operators/tick/) - For filtering with optimized interval scans
 
-## interval_start
-
-`interval_start(interval)` - extracts the lower bound of the interval.
-
-Use to extract bounds from intervals returned by functions or stored in columns.
-
-**Arguments:**
-
-- `interval` is an `interval`.
-
-**Return value:**
-
-Return value type is `timestamp` or `timestamp_ns`, depending on the type of values in the interval.
-
-**Examples:**
-
-```questdb-sql title="Extract an interval lower bound" demo
-SELECT
-  interval_start(
-    interval('2024-10-08T11:09:47.573Z', '2024-10-09T11:09:47.573Z')
-  )
-```
-
-| interval_start              |
-| :-------------------------- |
-| 2024-10-08T11:09:47.573000Z |
-
 ## interval_end
 
 `interval_end(interval)` - extracts the upper bound of the interval.
@@ -635,6 +608,33 @@ SELECT
 | interval_end                |
 | :-------------------------- |
 | 2024-10-09T11:09:47.573000Z |
+
+## interval_start
+
+`interval_start(interval)` - extracts the lower bound of the interval.
+
+Use to extract bounds from intervals returned by functions or stored in columns.
+
+**Arguments:**
+
+- `interval` is an `interval`.
+
+**Return value:**
+
+Return value type is `timestamp` or `timestamp_ns`, depending on the type of values in the interval.
+
+**Examples:**
+
+```questdb-sql title="Extract an interval lower bound" demo
+SELECT
+  interval_start(
+    interval('2024-10-08T11:09:47.573Z', '2024-10-09T11:09:47.573Z')
+  )
+```
+
+| interval_start              |
+| :-------------------------- |
+| 2024-10-08T11:09:47.573000Z |
 
 ## is_leap_year
 
@@ -994,75 +994,6 @@ SELECT second(ts), count() FROM transactions;
 | 58     | 9876  |
 | 59     | 2567  |
 
-## today, tomorrow, yesterday
-
-- `today()` - returns an interval representing the current day.
-
-- `tomorrow()` - returns an interval representing the next day.
-
-- `yesterday()` - returns an interval representing the previous day.
-
-Interval is in the UTC/GMT+0 timezone.
-
-These functions return intervals for use in projections or comparisons. For
-filtering in WHERE clauses, prefer [TICK syntax](/docs/query/operators/tick/)
-(`$today`, `$tomorrow`, `$yesterday`) which enables
-[interval scan](/docs/concepts/deep-dive/interval-scan/) optimization.
-
-**Arguments:**
-
-No arguments taken.
-
-**Return value:**
-
-Return value is of type `interval`.
-
-**Examples:**
-
-```questdb-sql title="Using today"
-SELECT true as in_today FROM long_sequence(1)
-WHERE now() IN today();
-```
-
-## today, tomorrow, yesterday with timezone
-
-- `today(timezone)` - returns an interval representing the current day with
-  timezone adjustment.
-
-- `tomorrow(timezone)` - returns an interval representing the next day timezone
-  adjustment.
-
-- `yesterday(timezone)` - returns an interval representing the previous day
-  timezone adjustment.
-
-**Arguments:**
-
-`timezone` is a `string` matching a timezone.
-
-**Return value:**
-
-Return value is of type `interval`.
-
-**Examples:**
-
-```questdb-sql title="Using today" demo
-SELECT today() as today, today('CEST') as adjusted;
-```
-
-| today                                                    | adjusted                                                 |
-| :------------------------------------------------------- | :------------------------------------------------------- |
-| ('2024-10-08T00:00:00.000Z', '2024-10-08T23:59:59.999Z') | ('2024-10-07T22:00:00.000Z', '2024-10-08T21:59:59.999Z') |
-
-This function allows the user to specify their local timezone and receive a UTC
-interval that corresponds to their 'day'.
-
-In this example, `CEST` is a +2h offset, so the `CEST` day started at `10:00 PM`
-`UTC` the day before.
-
-#### See also
-
-- [TICK syntax](/docs/query/operators/tick/) - Use `$today`, `$tomorrow`, `$yesterday` for optimized filtering
-
 ## sysdate
 
 `sysdate()` - returns the timestamp of the host system as a `date` with
@@ -1174,6 +1105,75 @@ VALUES(systimestamp_ns(), 123.5);
 | ts                             | reading |
 | :----------------------------- | :------ |
 | 2020-01-02T19:28:48.727516132Z | 123.5   |
+
+## today, tomorrow, yesterday
+
+- `today()` - returns an interval representing the current day.
+
+- `tomorrow()` - returns an interval representing the next day.
+
+- `yesterday()` - returns an interval representing the previous day.
+
+Interval is in the UTC/GMT+0 timezone.
+
+These functions return intervals for use in projections or comparisons. For
+filtering in WHERE clauses, prefer [TICK syntax](/docs/query/operators/tick/)
+(`$today`, `$tomorrow`, `$yesterday`) which enables
+[interval scan](/docs/concepts/deep-dive/interval-scan/) optimization.
+
+**Arguments:**
+
+No arguments taken.
+
+**Return value:**
+
+Return value is of type `interval`.
+
+**Examples:**
+
+```questdb-sql title="Using today"
+SELECT true as in_today FROM long_sequence(1)
+WHERE now() IN today();
+```
+
+## today, tomorrow, yesterday with timezone
+
+- `today(timezone)` - returns an interval representing the current day with
+  timezone adjustment.
+
+- `tomorrow(timezone)` - returns an interval representing the next day timezone
+  adjustment.
+
+- `yesterday(timezone)` - returns an interval representing the previous day
+  timezone adjustment.
+
+**Arguments:**
+
+`timezone` is a `string` matching a timezone.
+
+**Return value:**
+
+Return value is of type `interval`.
+
+**Examples:**
+
+```questdb-sql title="Using today" demo
+SELECT today() as today, today('CEST') as adjusted;
+```
+
+| today                                                    | adjusted                                                 |
+| :------------------------------------------------------- | :------------------------------------------------------- |
+| ('2024-10-08T00:00:00.000Z', '2024-10-08T23:59:59.999Z') | ('2024-10-07T22:00:00.000Z', '2024-10-08T21:59:59.999Z') |
+
+This function allows the user to specify their local timezone and receive a UTC
+interval that corresponds to their 'day'.
+
+In this example, `CEST` is a +2h offset, so the `CEST` day started at `10:00 PM`
+`UTC` the day before.
+
+#### See also
+
+- [TICK syntax](/docs/query/operators/tick/) - Use `$today`, `$tomorrow`, `$yesterday` for optimized filtering
 
 ## timestamp_ceil
 

--- a/documentation/query/functions/finance.md
+++ b/documentation/query/functions/finance.md
@@ -524,18 +524,18 @@ SELECT spread_bps(1.5760, 1.5763)
 | :------------- |
 | 1.903372140976 |
 
-## VWAP (Volume-Weighted Average Price)
-
-For VWAP calculations, use window functions with the typical price formula. This approach is more flexible and works well with high-frequency market data.
-
-See the [VWAP example in Window Functions](/docs/query/functions/window-functions/overview#vwap-volume-weighted-average-price) for the recommended implementation using `SAMPLE BY` and `CUMULATIVE` window frames.
-
 ## TWAP (Time-Weighted Average Price)
 
 QuestDB provides a native `twap(price, timestamp)` aggregate function that computes the time-weighted average price using step-function integration. Unlike VWAP, TWAP gives equal weight to every time interval, making it the preferred benchmark for illiquid instruments or when volume data is unavailable. It supports `GROUP BY`, `SAMPLE BY`, and `FILL` modes.
 
 - [Function reference](/docs/query/functions/aggregation#twap) — syntax, parameters, and formula
 - [Cookbook recipe](/docs/cookbook/sql/finance/twap/) — practical examples with TWAP-vs-VWAP comparison
+
+## VWAP (Volume-Weighted Average Price)
+
+For VWAP calculations, use window functions with the typical price formula. This approach is more flexible and works well with high-frequency market data.
+
+See the [VWAP example in Window Functions](/docs/query/functions/window-functions/overview#vwap-volume-weighted-average-price) for the recommended implementation using `SAMPLE BY` and `CUMULATIVE` window frames.
 
 ## wmid
 

--- a/documentation/query/functions/meta.md
+++ b/documentation/query/functions/meta.md
@@ -34,6 +34,44 @@ SELECT build();
 | -------------------------------------------------------------------------------------------------- |
 | Build Information: QuestDB 7.3.5, JDK 17.0.7, Commit Hash 460b817b0a3705c5633619a8ef9efb5163f1569c |
 
+## current database, schema, or user
+
+`current_database()`, `current_schema()`, and `current_user()` are standard SQL
+functions that return information about the current database, schema, schemas,
+and user, respectively.
+
+```questdb-sql
+-- Get the current database
+SELECT current_database();
+
+-- Get the current schema
+SELECT current_schema();
+
+-- Get the current user
+SELECT current_user();
+```
+
+Each of these functions returns a single value, so you can use them in a SELECT
+statement without any arguments.
+
+## flush_query_cache()
+
+`flush_query_cache' invalidates cached query execution plans.
+
+**Arguments:**
+
+- `flush_query_cache()` does not require arguments.
+
+**Return value:**
+
+Returns `boolean`. `true` if successful, `false` if unsuccessful.
+
+**Examples:**
+
+```questdb-sql title="Flush cached query execution plans"
+SELECT flush_query_cache();
+```
+
 ## functions
 
 **Arguments:**
@@ -55,6 +93,116 @@ functions();
 | or   | or(TT)    | or(boolean, boolean)  | FALSE            | STANDARD |
 | and  | and(TT)   | and(boolean, boolean) | FALSE            | STANDARD |
 | not  | not(T)    | not(boolean)          | FALSE            | STANDARD |
+
+## hydrate_table_metadata('table1', 'table2' ...)
+
+`hydrate_table_metadata' re-reads table metadata from disk to update the static
+metadata cache.
+
+:::warning
+
+This function should only be used when directed by QuestDB support. Misuse could
+cause corruption of the metadata cache, requiring the database to be restarted.
+
+:::
+
+**Arguments:**
+
+A variable list of strings, corresponding to table names.
+
+Alternatively, a single asterisk, '\*', representing all tables.
+
+**Return value:**
+
+Returns `boolean`. `true` if successful, `false` if unsuccessful.
+
+**Examples:**
+
+Simply pass table names as arguments to the function.
+
+```
+SELECT hydrate_table_metadata('trades', 'trips');
+```
+
+| hydrate_table_metadata |
+| ---------------------- |
+| true                   |
+
+If you want to re-read metadata for all user tables, simply use an asterisk:
+
+```
+SELECT hydrate_table_metadata('*');
+```
+
+## materialized_views
+
+`materialized_views()` returns the list of all materialized views in the
+database.
+
+**Arguments:**
+
+- `materialized_views()` does not require arguments.
+
+**Return value:**
+
+Returns a `table` including the following information:
+
+- `view_name` - materialized view name
+- `refresh_type` - refresh strategy type
+- `base_table_name` - base table name
+- `last_refresh_start_timestamp` - last time when an incremental refresh for the
+  view was started
+- `last_refresh_finish_timestamp` - last time when an incremental refresh for
+  the view finished
+- `view_sql` - query used to populate view data
+- `view_table_dir_name` - view directory name
+- `invalidation_reason` - message explaining why the view was marked as invalid
+- `view_status` - view status: 'valid', 'refreshing', or 'invalid'
+- `refresh_base_table_txn` - the last base table transaction used to refresh the
+  materialized view
+- `base_table_txn` - the last committed transaction in the base table
+- `refresh_limit_value` - how many units back in time the refresh limit goes
+- `refresh_limit_unit` - how long each unit is
+- `timer_start` - start date for the scheduled refresh timer
+- `timer_interval_value` - how many interval units between each refresh
+- `timer_interval_unit` - how long each unit is
+
+**Examples:**
+
+```questdb-sql title="List all materialized views"
+materialized_views();
+```
+
+| view_name        | refresh_type | base_table_name | last_refresh_start_timestamp | last_refresh_finish_timestamp | view_sql                                                                                                                                                     | view_table_dir_name | invalidation_reason | view_status | refresh_base_table_txn | base_table_txn | refresh_limit_value | refresh_limit_unit | timer_start | timer_interval_value | timer_interval_unit |
+|------------------|--------------|-----------------|------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|---------------------|-------------|------------------------|----------------|---------------------|--------------------|-------------|----------------------|---------------------|
+| trades_OHLC_15m  | immediate   | trades          | 2025-05-30T16:40:37.562421Z  | 2025-05-30T16:40:37.568800Z   | SELECT timestamp, symbol, first(price) AS open, max(price) as high, min(price) as low, last(price) AS close, sum(amount) AS volume FROM trades SAMPLE BY 15m | trades_OHLC_15m~27  | null                | valid       | 55141609               | 55141609       | 0                   | null               | null        | 0                    | null                |
+| trades_latest_1d | immediate   | trades          | 2025-05-30T16:40:37.554274Z  | 2025-05-30T16:40:37.562049Z   | SELECT timestamp, symbol, side, last(price) AS price, last(amount) AS amount, last(timestamp) as latest FROM trades SAMPLE BY 1d                             | trades_latest_1d~28 | null                | valid       | 55141609               | 55141609       | 0                   | null               | null        | 0                    | null                |
+
+
+## memory_metrics
+
+**Arguments:**
+
+- `memory_metrics()` does not require arguments.
+
+**Return value:**
+
+Returns granular memory metrics.
+
+**Examples:**
+
+```questdb-sql
+memory_metrics();
+```
+
+| memory_tag     | bytes     |
+| -------------- | --------- |
+| TOTAL_USED     | 142624730 |
+| RSS            | 328609792 |
+| MMAP_DEFAULT   | 196728    |
+| NATIVE_DEFAULT | 256       |
+| MMAP_O3        | 0         |
+| NATIVE_O3      | 96        |
 
 ## query_activity
 
@@ -89,31 +237,6 @@ SELECT * FROM query_activity();
 | 62179    | 5         | shared      | bob      | 2024-01-09T10:03:05.557397Z | 2024-01-09T10:03:05.557397  | active | select \* from query_activity()                           |
 | 57777    | 6         | shared      | bob      | 2024-01-09T08:58:55.988017Z | 2024-01-09T08:58:55.988017Z | active | SELECT symbol,approx_percentile(price, 50, 2) from trades |
 
-## memory_metrics
-
-**Arguments:**
-
-- `memory_metrics()` does not require arguments.
-
-**Return value:**
-
-Returns granular memory metrics.
-
-**Examples:**
-
-```questdb-sql
-memory_metrics();
-```
-
-| memory_tag     | bytes     |
-| -------------- | --------- |
-| TOTAL_USED     | 142624730 |
-| RSS            | 328609792 |
-| MMAP_DEFAULT   | 196728    |
-| NATIVE_DEFAULT | 256       |
-| MMAP_O3        | 0         |
-| NATIVE_O3      | 96        |
-
 ## reader_pool
 
 **Arguments:**
@@ -139,53 +262,244 @@ SELECT * FROM reader_pool();
 | ---------- | --------------- | --------------------------- | ----------- |
 | sensors    | null            | 2023-12-01T19:28:14.311703Z | 1           |
 
-## writer_pool
+## reload_config()
+
+`reload_config' reloads server configuration file's contents (`server.conf`)
+without server restart. The list of reloadable settings can be found
+[here](/docs/configuration/overview/#reloadable-settings).
 
 **Arguments:**
 
-- `writer_pool()` does not require arguments.
+- `reload_config()` does not require arguments.
 
 **Return value:**
 
-Returns information about the current state of the writer pool in QuestDB. The
-writer pool is a cache of table writers that are kept open to speed up
-subsequent writes to the same table. The returned information includes the table
-name, the ID of the thread that currently owns the writer, the timestamp of the
-last time the writer was accessed, and the reason for the ownership.
+Returns `boolean`. `true` if any configuration properties were reloaded, `false`
+if none were reloaded.
 
 **Examples:**
 
-```questdb-sql
-SELECT * FROM writer_pool();
+Edit `server.conf` and run `reload_config`:
+
+```questdb-sql title="Reload server configuration"
+SELECT reload_config();
 ```
 
-| table_name                    | owner_thread_id | last_access_timestamp       | ownership_reason |
-| ----------------------------- | --------------- | --------------------------- | ---------------- |
-| sys.column_versions_purge_log | 1               | 2023-12-01T18:50:03.412468Z | QuestDB system   |
-| telemetry_config              | 1               | 2023-12-01T18:50:03.470604Z | telemetryConfig  |
-| telemetry                     | 1               | 2023-12-01T18:50:03.464501Z | telemetry        |
-| sys.telemetry_wal             | 1               | 2023-12-01T18:50:03.467924Z | telemetry        |
-| example_table                 | null            | 2023-12-01T20:33:33.270984Z | null             |
+## table_columns
 
-## current database, schema, or user
+`table_columns('tableName')` returns the schema of a table or a materialized
+view.
 
-`current_database()`, `current_schema()`, and `current_user()` are standard SQL
-functions that return information about the current database, schema, schemas,
-and user, respectively.
+**Arguments:**
 
-```questdb-sql
--- Get the current database
-SELECT current_database();
+- `tableName` is the name of an existing table or materialized view as a string.
 
--- Get the current schema
-SELECT current_schema();
+**Return value:**
 
--- Get the current user
-SELECT current_user();
+Returns a `table` with the following columns:
+
+- `column` - name of the available columns in the table
+- `type` - type of the column
+- `indexed` - if indexing is applied to this column
+- `indexBlockCapacity` - how many row IDs to store in a single storage block on
+  disk
+- `symbolCached` - whether this `symbol` column is cached
+- `symbolCapacity` - how many distinct values this column of `symbol` type is
+  expected to have
+- `designated` - if this is set as the designated timestamp column for this
+  table
+- `upsertKey` - if this column is a part of UPSERT KEYS list for table
+  [deduplication](/docs/concepts/deduplication)
+
+For more details on the meaning and use of these values, see the
+[CREATE TABLE](/docs/query/sql/create-table/) documentation.
+
+**Examples:**
+
+```questdb-sql title="Get all columns in a table"
+table_columns('my_table');
 ```
 
-Each of these functions returns a single value, so you can use them in a SELECT
-statement without any arguments.
+| column | type      | indexed | indexBlockCapacity | symbolCached | symbolCapacity | designated | upsertKey |
+| ------ | --------- | ------- | ------------------ | ------------ | -------------- | ---------- | --------- |
+| symb   | SYMBOL    | true    | 1048576            | false        | 256            | false      | false     |
+| price  | DOUBLE    | false   | 0                  | false        | 0              | false      | false     |
+| ts     | TIMESTAMP | false   | 0                  | false        | 0              | true       | false     |
+| s      | VARCHAR   | false   | 0                  | false        | 0              | false      | false     |
+
+```questdb-sql title="Get designated timestamp column"
+SELECT "column", type, designated FROM table_columns('my_table') WHERE designated = true;
+```
+
+| column | type      | designated |
+| ------ | --------- | ---------- |
+| ts     | TIMESTAMP | true       |
+
+```questdb-sql title="Get the count of column types"
+SELECT type, count() FROM table_columns('my_table');
+```
+
+| type      | count |
+| --------- | ----- |
+| SYMBOL    | 1     |
+| DOUBLE    | 1     |
+| TIMESTAMP | 1     |
+| VARCHAR   | 1     |
+
+## table_partitions
+
+`table_partitions('tableName')` returns information for the partitions of a
+table or a materialized view with the option to filter the partitions.
+
+**Arguments:**
+
+- `tableName` is the name of an existing table or materialized view as a string.
+
+**Return value:**
+
+Returns a table with the following columns:
+
+- `index` - _INTEGER_, index of the partition (_NaN_ when the partition is not
+  attached)
+- `partitionBy` - _STRING_, one of _NONE_, _HOUR_, _DAY_, _WEEK_, _MONTH_ and
+  _YEAR_
+- `name` - _STRING_, name of the partition, e.g. `2023-03-14`,
+  `2023-03-14.detached`, `2023-03-14.attachable`
+- `minTimestamp` - _LONG_, min timestamp of the partition (_NaN_ when the table
+  is not partitioned)
+- `maxTimestamp` - _LONG_, max timestamp of the partition (_NaN_ when the table
+  is not partitioned)
+- `numRows` - _LONG_, number of rows in the partition
+- `diskSize` - _LONG_, size of the partition in bytes
+- `diskSizeHuman` - _STRING_, size of the partition meant for humans to read
+  (same output as function
+  [size_pretty](/docs/query/functions/numeric/#size_pretty))
+- `readOnly` - _BOOLEAN_, true if the partition is
+  [attached via soft link](/docs/query/sql/alter-table-attach-partition/#symbolic-links)
+- `active` - _BOOLEAN_, true if the partition is the last partition, and whether
+  we are writing to it (at least one record)
+- `attached` - _BOOLEAN_, true if the partition is
+  [attached](/docs/query/sql/alter-table-attach-partition/)
+- `detached` - _BOOLEAN_, true if the partition is
+  [detached](/docs/query/sql/alter-table-detach-partition/) (`name` of the
+  partition will contain the `.detached` extension)
+- `attachable` - _BOOLEAN_, true if the partition is detached and can be
+  attached (`name` of the partition will contain the `.attachable` extension)
+
+**Examples:**
+
+```questdb-sql title="Create table my_table"
+CREATE TABLE my_table AS (
+    SELECT
+        rnd_symbol('EURO', 'USD', 'OTHER') symbol,
+        rnd_double() * 50.0 price,
+        rnd_double() * 20.0 amount,
+        to_timestamp('2023-01-01', 'yyyy-MM-dd') + x * 6 * 3600 * 100000L timestamp
+    FROM long_sequence(700)
+), INDEX(symbol capacity 32) TIMESTAMP(timestamp) PARTITION BY WEEK;
+```
+
+```questdb-sql title="Get all partitions from my_table"
+table_partitions('my_table');
+```
+
+| index | partitionBy | name     | minTimestamp          | maxTimestamp          | numRows | diskSize | diskSizeHuman | readOnly | active | attached | detached | attachable |
+| ----- | ----------- | -------- | --------------------- | --------------------- | ------- | -------- | ------------- | -------- | ------ | -------- | -------- | ---------- |
+| 0     | WEEK        | 2022-W52 | 2023-01-01 00:36:00.0 | 2023-01-01 23:24:00.0 | 39      | 98304    | 96.0 KiB      | false    | false  | true     | false    | false      |
+| 1     | WEEK        | 2023-W01 | 2023-01-02 00:00:00.0 | 2023-01-08 23:24:00.0 | 280     | 98304    | 96.0 KiB      | false    | false  | true     | false    | false      |
+| 2     | WEEK        | 2023-W02 | 2023-01-09 00:00:00.0 | 2023-01-15 23:24:00.0 | 280     | 98304    | 96.0 KiB      | false    | false  | true     | false    | false      |
+| 3     | WEEK        | 2023-W03 | 2023-01-16 00:00:00.0 | 2023-01-18 12:00:00.0 | 101     | 83902464 | 80.0 MiB      | false    | true   | true     | false    | false      |
+
+```questdb-sql title="Get size of a table in disk"
+SELECT size_pretty(sum(diskSize)) FROM table_partitions('my_table');
+```
+
+| size_pretty |
+| ----------- |
+| 80.3 MB     |
+
+```questdb-sql title="Get active partition of a table"
+SELECT * FROM table_partitions('my_table') WHERE active = true;
+```
+
+| index | partitionBy | name     | minTimestamp          | maxTimestamp          | numRows | diskSize | diskSizeHuman | readOnly | active | attached | detached | attachable |
+| ----- | ----------- | -------- | --------------------- | --------------------- | ------- | -------- | ------------- | -------- | ------ | -------- | -------- | ---------- |
+| 3     | WEEK        | 2023-W03 | 2023-01-16 00:00:00.0 | 2023-01-18 12:00:00.0 | 101     | 83902464 | 80.0 MiB      | false    | true   | true     | false    | false      |
+
+## table_storage
+
+`table_storage()` - Returns information about the storage and structure of all
+user tables and materialized views in the database.
+
+Provides detailed storage information about all user tables and materialized
+views within QuestDB. It returns one row per table, including information about
+partitioning, row counts, and disk usage.
+
+- The `table_storage()` function excludes system tables; it only lists
+  user-created tables.
+- The `diskSize` value represents the total size of all files associated with
+  the table on disk, including data, index, and metadata files.
+- The `partitionBy` column indicates the partitioning strategy used for the
+  table. It can be `NONE` if the table is not partitioned.
+
+**Return values:**
+
+The function returns the following columns:
+
+- `tableName` (`string`): The name of the table or materialized view.
+- `walEnabled` (`boolean`): Indicates whether Write-Ahead Logging (WAL) is
+  enabled for the table.
+- `partitionBy` (`string`): The partitioning type of the table (e.g., NONE, DAY,
+  MONTH, YEAR, etc.).
+- `partitionCount` (`long`): The number of partitions the table has.
+- `rowCount` (`long`): The total number of rows in the table.
+- `diskSize` (`long`): The total disk space used by the table, in bytes.
+
+**Examples:**
+
+Retrieve storage information for all tables.
+
+```questdb-sql title="Checking our demo tables" demo
+SELECT * FROM table_storage();
+```
+
+- The query retrieves storage details for all tables in the database.
+- The `diskSize` column shows the total disk space used by each table in bytes.
+
+| tableName      | walEnabled | partitionBy | partitionCount | rowCount   | diskSize     |
+| -------------- | ---------- | ----------- | -------------- | ---------- | ------------ |
+| trips          | true       | MONTH       | 126            | 1634599313 | 261536158948 |
+| AAPL_orderbook | true       | HOUR        | 16             | 3024878    | 2149403527   |
+| weather        | false      | NONE        | 1              | 137627     | 9972598      |
+| trades         | true       | DAY         | 954            | 1000848308 | 32764798760  |
+| ethblocks_json | true       | DAY         | 3328           | 20688364   | 28311960478  |
+
+<hr />
+
+Filter tables with WAL enabled.
+
+```questdb-sql title="WAL only tables" demo
+SELECT tableName, rowCount, diskSize
+FROM table_storage()
+WHERE walEnabled = true;
+```
+
+| tableName      | rowCount   | diskSize     |
+| -------------- | ---------- | ------------ |
+| trips          | 1634599313 | 261536158948 |
+| AAPL_orderbook | 3024878    | 2149403527   |
+| trades         | 1000850255 | 32764804264  |
+| ethblocks_json | 20688364   | 28311960478  |
+
+<hr />
+
+Show tables partitioned by `HOUR`.
+
+```questdb-sql title="Show tables partitioned by hour" demo
+SELECT tableName, partitionCount, rowCount
+FROM table_storage()
+WHERE partitionBy = 'HOUR';
+```
 
 ## tables
 
@@ -457,79 +771,72 @@ ORDER BY
     wal_pending_row_count DESC;
 ```
 
-## table_storage
+## version/pg_catalog.version
 
-`table_storage()` - Returns information about the storage and structure of all
-user tables and materialized views in the database.
+`version()` or `pg_catalog.version()` returns the supported version of the
+PostgreSQL Wire Protocol.
 
-Provides detailed storage information about all user tables and materialized
-views within QuestDB. It returns one row per table, including information about
-partitioning, row counts, and disk usage.
+**Arguments:**
 
-- The `table_storage()` function excludes system tables; it only lists
-  user-created tables.
-- The `diskSize` value represents the total size of all files associated with
-  the table on disk, including data, index, and metadata files.
-- The `partitionBy` column indicates the partitioning strategy used for the
-  table. It can be `NONE` if the table is not partitioned.
+- `version()` or `pg_catalog.version()` does not require arguments.
 
-**Return values:**
+**Return value:**
 
-The function returns the following columns:
-
-- `tableName` (`string`): The name of the table or materialized view.
-- `walEnabled` (`boolean`): Indicates whether Write-Ahead Logging (WAL) is
-  enabled for the table.
-- `partitionBy` (`string`): The partitioning type of the table (e.g., NONE, DAY,
-  MONTH, YEAR, etc.).
-- `partitionCount` (`long`): The number of partitions the table has.
-- `rowCount` (`long`): The total number of rows in the table.
-- `diskSize` (`long`): The total disk space used by the table, in bytes.
+Returns `string`.
 
 **Examples:**
 
-Retrieve storage information for all tables.
+```questdb-sql
+SELECT version();
 
-```questdb-sql title="Checking our demo tables" demo
-SELECT * FROM table_storage();
+--The above equals to:
+
+SELECT pg_catalog.version();
 ```
 
-- The query retrieves storage details for all tables in the database.
-- The `diskSize` column shows the total disk space used by each table in bytes.
+| version                                                             |
+| ------------------------------------------------------------------- |
+| PostgreSQL 12.3, compiled by Visual C++ build 1914, 64-bit, QuestDB |
 
-| tableName      | walEnabled | partitionBy | partitionCount | rowCount   | diskSize     |
-| -------------- | ---------- | ----------- | -------------- | ---------- | ------------ |
-| trips          | true       | MONTH       | 126            | 1634599313 | 261536158948 |
-| AAPL_orderbook | true       | HOUR        | 16             | 3024878    | 2149403527   |
-| weather        | false      | NONE        | 1              | 137627     | 9972598      |
-| trades         | true       | DAY         | 954            | 1000848308 | 32764798760  |
-| ethblocks_json | true       | DAY         | 3328           | 20688364   | 28311960478  |
+## views
 
-<hr />
+`views()` returns the list of all views in the database.
 
-Filter tables with WAL enabled.
+**Arguments:**
 
-```questdb-sql title="WAL only tables" demo
-SELECT tableName, rowCount, diskSize
-FROM table_storage()
-WHERE walEnabled = true;
+- `views()` does not require arguments.
+
+**Return value:**
+
+Returns a `table` including the following information:
+
+- `view_name` - view name
+- `view_sql` - query used to define the view (without CREATE VIEW wrapper)
+- `view_table_dir_name` - internal directory name
+- `invalidation_reason` - message explaining why the view was marked as invalid,
+  empty if valid
+- `view_status` - view status: `valid` or `invalid`
+- `view_status_update_time` - timestamp of last status change
+
+**Examples:**
+
+```questdb-sql title="List all views"
+views();
 ```
 
-| tableName      | rowCount   | diskSize     |
-| -------------- | ---------- | ------------ |
-| trips          | 1634599313 | 261536158948 |
-| AAPL_orderbook | 3024878    | 2149403527   |
-| trades         | 1000850255 | 32764804264  |
-| ethblocks_json | 20688364   | 28311960478  |
+| view_name      | view_sql                                              | view_table_dir_name | invalidation_reason | view_status | view_status_update_time     |
+| -------------- | ----------------------------------------------------- | ------------------- | ------------------- | ----------- | --------------------------- |
+| hourly_summary | SELECT ts, symbol, sum(qty) FROM trades SAMPLE BY 1h  | hourly_summary~1    |                     | valid       | 2025-05-30T10:15:00.000000Z |
+| price_view     | SELECT symbol, last(price) FROM trades SAMPLE BY 1d   | price_view~2        |                     | valid       | 2025-05-30T10:20:00.000000Z |
 
-<hr />
+```questdb-sql title="Find invalid views"
+SELECT view_name, invalidation_reason
+FROM views()
+WHERE view_status = 'invalid';
+```
 
-Show tables partitioned by `HOUR`.
-
-```questdb-sql title="Show tables partitioned by hour" demo
-SELECT tableName, partitionCount, rowCount
-FROM table_storage()
-WHERE partitionBy = 'HOUR';
+```questdb-sql title="List views ordered by name"
+SELECT * FROM views() ORDER BY view_name;
 ```
 
 ## wal_tables
@@ -576,337 +883,30 @@ wal_tables();
 | weather_wal | false     | 3         | 0                 | 3            |
 | test_wal    | true      | 7         | 1                 | 9            |
 
-## table_columns
-
-`table_columns('tableName')` returns the schema of a table or a materialized
-view.
+## writer_pool
 
 **Arguments:**
 
-- `tableName` is the name of an existing table or materialized view as a string.
+- `writer_pool()` does not require arguments.
 
 **Return value:**
 
-Returns a `table` with the following columns:
-
-- `column` - name of the available columns in the table
-- `type` - type of the column
-- `indexed` - if indexing is applied to this column
-- `indexBlockCapacity` - how many row IDs to store in a single storage block on
-  disk
-- `symbolCached` - whether this `symbol` column is cached
-- `symbolCapacity` - how many distinct values this column of `symbol` type is
-  expected to have
-- `designated` - if this is set as the designated timestamp column for this
-  table
-- `upsertKey` - if this column is a part of UPSERT KEYS list for table
-  [deduplication](/docs/concepts/deduplication)
-
-For more details on the meaning and use of these values, see the
-[CREATE TABLE](/docs/query/sql/create-table/) documentation.
-
-**Examples:**
-
-```questdb-sql title="Get all columns in a table"
-table_columns('my_table');
-```
-
-| column | type      | indexed | indexBlockCapacity | symbolCached | symbolCapacity | designated | upsertKey |
-| ------ | --------- | ------- | ------------------ | ------------ | -------------- | ---------- | --------- |
-| symb   | SYMBOL    | true    | 1048576            | false        | 256            | false      | false     |
-| price  | DOUBLE    | false   | 0                  | false        | 0              | false      | false     |
-| ts     | TIMESTAMP | false   | 0                  | false        | 0              | true       | false     |
-| s      | VARCHAR   | false   | 0                  | false        | 0              | false      | false     |
-
-```questdb-sql title="Get designated timestamp column"
-SELECT "column", type, designated FROM table_columns('my_table') WHERE designated = true;
-```
-
-| column | type      | designated |
-| ------ | --------- | ---------- |
-| ts     | TIMESTAMP | true       |
-
-```questdb-sql title="Get the count of column types"
-SELECT type, count() FROM table_columns('my_table');
-```
-
-| type      | count |
-| --------- | ----- |
-| SYMBOL    | 1     |
-| DOUBLE    | 1     |
-| TIMESTAMP | 1     |
-| VARCHAR   | 1     |
-
-## table_partitions
-
-`table_partitions('tableName')` returns information for the partitions of a
-table or a materialized view with the option to filter the partitions.
-
-**Arguments:**
-
-- `tableName` is the name of an existing table or materialized view as a string.
-
-**Return value:**
-
-Returns a table with the following columns:
-
-- `index` - _INTEGER_, index of the partition (_NaN_ when the partition is not
-  attached)
-- `partitionBy` - _STRING_, one of _NONE_, _HOUR_, _DAY_, _WEEK_, _MONTH_ and
-  _YEAR_
-- `name` - _STRING_, name of the partition, e.g. `2023-03-14`,
-  `2023-03-14.detached`, `2023-03-14.attachable`
-- `minTimestamp` - _LONG_, min timestamp of the partition (_NaN_ when the table
-  is not partitioned)
-- `maxTimestamp` - _LONG_, max timestamp of the partition (_NaN_ when the table
-  is not partitioned)
-- `numRows` - _LONG_, number of rows in the partition
-- `diskSize` - _LONG_, size of the partition in bytes
-- `diskSizeHuman` - _STRING_, size of the partition meant for humans to read
-  (same output as function
-  [size_pretty](/docs/query/functions/numeric/#size_pretty))
-- `readOnly` - _BOOLEAN_, true if the partition is
-  [attached via soft link](/docs/query/sql/alter-table-attach-partition/#symbolic-links)
-- `active` - _BOOLEAN_, true if the partition is the last partition, and whether
-  we are writing to it (at least one record)
-- `attached` - _BOOLEAN_, true if the partition is
-  [attached](/docs/query/sql/alter-table-attach-partition/)
-- `detached` - _BOOLEAN_, true if the partition is
-  [detached](/docs/query/sql/alter-table-detach-partition/) (`name` of the
-  partition will contain the `.detached` extension)
-- `attachable` - _BOOLEAN_, true if the partition is detached and can be
-  attached (`name` of the partition will contain the `.attachable` extension)
-
-**Examples:**
-
-```questdb-sql title="Create table my_table"
-CREATE TABLE my_table AS (
-    SELECT
-        rnd_symbol('EURO', 'USD', 'OTHER') symbol,
-        rnd_double() * 50.0 price,
-        rnd_double() * 20.0 amount,
-        to_timestamp('2023-01-01', 'yyyy-MM-dd') + x * 6 * 3600 * 100000L timestamp
-    FROM long_sequence(700)
-), INDEX(symbol capacity 32) TIMESTAMP(timestamp) PARTITION BY WEEK;
-```
-
-```questdb-sql title="Get all partitions from my_table"
-table_partitions('my_table');
-```
-
-| index | partitionBy | name     | minTimestamp          | maxTimestamp          | numRows | diskSize | diskSizeHuman | readOnly | active | attached | detached | attachable |
-| ----- | ----------- | -------- | --------------------- | --------------------- | ------- | -------- | ------------- | -------- | ------ | -------- | -------- | ---------- |
-| 0     | WEEK        | 2022-W52 | 2023-01-01 00:36:00.0 | 2023-01-01 23:24:00.0 | 39      | 98304    | 96.0 KiB      | false    | false  | true     | false    | false      |
-| 1     | WEEK        | 2023-W01 | 2023-01-02 00:00:00.0 | 2023-01-08 23:24:00.0 | 280     | 98304    | 96.0 KiB      | false    | false  | true     | false    | false      |
-| 2     | WEEK        | 2023-W02 | 2023-01-09 00:00:00.0 | 2023-01-15 23:24:00.0 | 280     | 98304    | 96.0 KiB      | false    | false  | true     | false    | false      |
-| 3     | WEEK        | 2023-W03 | 2023-01-16 00:00:00.0 | 2023-01-18 12:00:00.0 | 101     | 83902464 | 80.0 MiB      | false    | true   | true     | false    | false      |
-
-```questdb-sql title="Get size of a table in disk"
-SELECT size_pretty(sum(diskSize)) FROM table_partitions('my_table');
-```
-
-| size_pretty |
-| ----------- |
-| 80.3 MB     |
-
-```questdb-sql title="Get active partition of a table"
-SELECT * FROM table_partitions('my_table') WHERE active = true;
-```
-
-| index | partitionBy | name     | minTimestamp          | maxTimestamp          | numRows | diskSize | diskSizeHuman | readOnly | active | attached | detached | attachable |
-| ----- | ----------- | -------- | --------------------- | --------------------- | ------- | -------- | ------------- | -------- | ------ | -------- | -------- | ---------- |
-| 3     | WEEK        | 2023-W03 | 2023-01-16 00:00:00.0 | 2023-01-18 12:00:00.0 | 101     | 83902464 | 80.0 MiB      | false    | true   | true     | false    | false      |
-
-## materialized_views
-
-`materialized_views()` returns the list of all materialized views in the
-database.
-
-**Arguments:**
-
-- `materialized_views()` does not require arguments.
-
-**Return value:**
-
-Returns a `table` including the following information:
-
-- `view_name` - materialized view name
-- `refresh_type` - refresh strategy type
-- `base_table_name` - base table name
-- `last_refresh_start_timestamp` - last time when an incremental refresh for the
-  view was started
-- `last_refresh_finish_timestamp` - last time when an incremental refresh for
-  the view finished
-- `view_sql` - query used to populate view data
-- `view_table_dir_name` - view directory name
-- `invalidation_reason` - message explaining why the view was marked as invalid
-- `view_status` - view status: 'valid', 'refreshing', or 'invalid'
-- `refresh_base_table_txn` - the last base table transaction used to refresh the
-  materialized view
-- `base_table_txn` - the last committed transaction in the base table
-- `refresh_limit_value` - how many units back in time the refresh limit goes
-- `refresh_limit_unit` - how long each unit is
-- `timer_start` - start date for the scheduled refresh timer
-- `timer_interval_value` - how many interval units between each refresh
-- `timer_interval_unit` - how long each unit is
-
-**Examples:**
-
-```questdb-sql title="List all materialized views"
-materialized_views();
-```
-
-| view_name        | refresh_type | base_table_name | last_refresh_start_timestamp | last_refresh_finish_timestamp | view_sql                                                                                                                                                     | view_table_dir_name | invalidation_reason | view_status | refresh_base_table_txn | base_table_txn | refresh_limit_value | refresh_limit_unit | timer_start | timer_interval_value | timer_interval_unit |
-|------------------|--------------|-----------------|------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|---------------------|-------------|------------------------|----------------|---------------------|--------------------|-------------|----------------------|---------------------|
-| trades_OHLC_15m  | immediate   | trades          | 2025-05-30T16:40:37.562421Z  | 2025-05-30T16:40:37.568800Z   | SELECT timestamp, symbol, first(price) AS open, max(price) as high, min(price) as low, last(price) AS close, sum(amount) AS volume FROM trades SAMPLE BY 15m | trades_OHLC_15m~27  | null                | valid       | 55141609               | 55141609       | 0                   | null               | null        | 0                    | null                |
-| trades_latest_1d | immediate   | trades          | 2025-05-30T16:40:37.554274Z  | 2025-05-30T16:40:37.562049Z   | SELECT timestamp, symbol, side, last(price) AS price, last(amount) AS amount, last(timestamp) as latest FROM trades SAMPLE BY 1d                             | trades_latest_1d~28 | null                | valid       | 55141609               | 55141609       | 0                   | null               | null        | 0                    | null                |
-
-
-## views
-
-`views()` returns the list of all views in the database.
-
-**Arguments:**
-
-- `views()` does not require arguments.
-
-**Return value:**
-
-Returns a `table` including the following information:
-
-- `view_name` - view name
-- `view_sql` - query used to define the view (without CREATE VIEW wrapper)
-- `view_table_dir_name` - internal directory name
-- `invalidation_reason` - message explaining why the view was marked as invalid,
-  empty if valid
-- `view_status` - view status: `valid` or `invalid`
-- `view_status_update_time` - timestamp of last status change
-
-**Examples:**
-
-```questdb-sql title="List all views"
-views();
-```
-
-| view_name      | view_sql                                              | view_table_dir_name | invalidation_reason | view_status | view_status_update_time     |
-| -------------- | ----------------------------------------------------- | ------------------- | ------------------- | ----------- | --------------------------- |
-| hourly_summary | SELECT ts, symbol, sum(qty) FROM trades SAMPLE BY 1h  | hourly_summary~1    |                     | valid       | 2025-05-30T10:15:00.000000Z |
-| price_view     | SELECT symbol, last(price) FROM trades SAMPLE BY 1d   | price_view~2        |                     | valid       | 2025-05-30T10:20:00.000000Z |
-
-```questdb-sql title="Find invalid views"
-SELECT view_name, invalidation_reason
-FROM views()
-WHERE view_status = 'invalid';
-```
-
-```questdb-sql title="List views ordered by name"
-SELECT * FROM views() ORDER BY view_name;
-```
-
-## version/pg_catalog.version
-
-`version()` or `pg_catalog.version()` returns the supported version of the
-PostgreSQL Wire Protocol.
-
-**Arguments:**
-
-- `version()` or `pg_catalog.version()` does not require arguments.
-
-**Return value:**
-
-Returns `string`.
+Returns information about the current state of the writer pool in QuestDB. The
+writer pool is a cache of table writers that are kept open to speed up
+subsequent writes to the same table. The returned information includes the table
+name, the ID of the thread that currently owns the writer, the timestamp of the
+last time the writer was accessed, and the reason for the ownership.
 
 **Examples:**
 
 ```questdb-sql
-SELECT version();
-
---The above equals to:
-
-SELECT pg_catalog.version();
+SELECT * FROM writer_pool();
 ```
 
-| version                                                             |
-| ------------------------------------------------------------------- |
-| PostgreSQL 12.3, compiled by Visual C++ build 1914, 64-bit, QuestDB |
-
-## hydrate_table_metadata('table1', 'table2' ...)
-
-`hydrate_table_metadata' re-reads table metadata from disk to update the static
-metadata cache.
-
-:::warning
-
-This function should only be used when directed by QuestDB support. Misuse could
-cause corruption of the metadata cache, requiring the database to be restarted.
-
-:::
-
-**Arguments:**
-
-A variable list of strings, corresponding to table names.
-
-Alternatively, a single asterisk, '\*', representing all tables.
-
-**Return value:**
-
-Returns `boolean`. `true` if successful, `false` if unsuccessful.
-
-**Examples:**
-
-Simply pass table names as arguments to the function.
-
-```
-SELECT hydrate_table_metadata('trades', 'trips');
-```
-
-| hydrate_table_metadata |
-| ---------------------- |
-| true                   |
-
-If you want to re-read metadata for all user tables, simply use an asterisk:
-
-```
-SELECT hydrate_table_metadata('*');
-```
-
-## flush_query_cache()
-
-`flush_query_cache' invalidates cached query execution plans.
-
-**Arguments:**
-
-- `flush_query_cache()` does not require arguments.
-
-**Return value:**
-
-Returns `boolean`. `true` if successful, `false` if unsuccessful.
-
-**Examples:**
-
-```questdb-sql title="Flush cached query execution plans"
-SELECT flush_query_cache();
-```
-
-## reload_config()
-
-`reload_config' reloads server configuration file's contents (`server.conf`)
-without server restart. The list of reloadable settings can be found
-[here](/docs/configuration/overview/#reloadable-settings).
-
-**Arguments:**
-
-- `reload_config()` does not require arguments.
-
-**Return value:**
-
-Returns `boolean`. `true` if any configuration properties were reloaded, `false`
-if none were reloaded.
-
-**Examples:**
-
-Edit `server.conf` and run `reload_config`:
-
-```questdb-sql title="Reload server configuration"
-SELECT reload_config();
-```
+| table_name                    | owner_thread_id | last_access_timestamp       | ownership_reason |
+| ----------------------------- | --------------- | --------------------------- | ---------------- |
+| sys.column_versions_purge_log | 1               | 2023-12-01T18:50:03.412468Z | QuestDB system   |
+| telemetry_config              | 1               | 2023-12-01T18:50:03.470604Z | telemetryConfig  |
+| telemetry                     | 1               | 2023-12-01T18:50:03.464501Z | telemetry        |
+| sys.telemetry_wal             | 1               | 2023-12-01T18:50:03.467924Z | telemetry        |
+| example_table                 | null            | 2023-12-01T20:33:33.270984Z | null             |

--- a/documentation/query/functions/random-value-generator.md
+++ b/documentation/query/functions/random-value-generator.md
@@ -418,6 +418,50 @@ To generate increasing timestamps, refer to the page about
 
 :::
 
+## rnd_timestamp_ns
+
+- `rnd_timestamp_ns(start, end, nanRate)` - generates a random nanosecond
+  timestamp between `start` and `end` timestamps (both inclusive). It will also
+  generate `NaN` values at a frequency defined by `nanRate`. When `start` or
+  `end` are invalid timestamps, or when `start` is superior to `end`, it will
+  return `invalid range` error. When `nanRate` is inferior to 0, it will return
+  `invalid NAN rate` error.
+
+This function is identical to [`rnd_timestamp`](#rnd_timestamp) but returns
+`timestamp_ns` (nanosecond resolution) instead of `timestamp` (microsecond
+resolution).
+
+**Arguments:**
+
+- `start` is a `timestamp` defining the minimum possible generated timestamp
+  (inclusive)
+- `end` is a `timestamp` defining the maximum possible generated timestamp
+  (inclusive)
+- `nanRate` defines the frequency of occurrence of `NaN` values:
+  - `0`: No `NaN` will be returned.
+  - `1`: Will only return `NaN`.
+  - `N > 1`: On average, one in N generated values will be NaN.
+
+**Return value:**
+
+Return value type is `timestamp_ns`.
+
+**Examples:**
+
+```questdb-sql title="Random nanosecond timestamp"
+SELECT rnd_timestamp_ns(
+    to_timestamp('2015', 'yyyy'),
+    to_timestamp('2016', 'yyyy'),
+    0)
+FROM long_sequence(5);
+```
+
+```
+2015-01-29T18:00:17.402762123Z, 2015-11-15T20:22:14.112744456Z,
+2015-12-08T09:26:04.483039789Z, 2015-05-28T02:22:47.022680012Z,
+2015-10-13T19:16:37.034203345Z
+```
+
 ## rnd_char
 
 - `rnd_char()` is used to generate a random `char` which will be an uppercase

--- a/documentation/query/functions/random-value-generator.md
+++ b/documentation/query/functions/random-value-generator.md
@@ -32,27 +32,28 @@ Values can be generated either:
 
 ## Function reference
 
+- [rnd_bin](#rnd_bin)
 - [rnd_boolean](#rnd_boolean)
 - [rnd_byte](#rnd_byte)
-- [rnd_short](#rnd_short)
+- [rnd_char](#rnd_char)
+- [rnd_date](#rnd_date)
+- [rnd_decimal](#rnd_decimal)
+- [rnd_double](#rnd_double)
+- [rnd_double_array](#rnd_double_array)
+- [rnd_float](#rnd_float)
 - [rnd_int](#rnd_int)
+- [rnd_ipv4](#rnd_ipv4)
 - [rnd_long](#rnd_long)
 - [rnd_long256](#rnd_long256)
-- [rnd_float](#rnd_float)
-- [rnd_double](#rnd_double)
-- [rnd_date](#rnd_date)
-- [rnd_timestamp](#rnd_timestamp)
-- [rnd_char](#rnd_char)
-- [rnd_symbol](#rnd_symbol)
-- [rnd_symbol_zipf](#rnd_symbol_zipf)
-- [rnd_symbol_weighted](#rnd_symbol_weighted)
-- [rnd_varchar](#rnd_varchar)
+- [rnd_short](#rnd_short)
 - [rnd_str](#rnd_str)
-- [rnd_bin](#rnd_bin)
+- [rnd_symbol](#rnd_symbol)
+- [rnd_symbol_weighted](#rnd_symbol_weighted)
+- [rnd_symbol_zipf](#rnd_symbol_zipf)
+- [rnd_timestamp](#rnd_timestamp)
+- [rnd_timestamp_ns](#rnd_timestamp_ns)
 - [rnd_uuid4](#rnd_uuid4)
-- [rnd_ipv4](#rnd_ipv4)
-- [rnd_double_array](#rnd_double_array)
-- [rnd_decimal](#rnd_decimal)
+- [rnd_varchar](#rnd_varchar)
 
 ## Usage
 
@@ -91,6 +92,35 @@ SELECT * FROM test WHERE val > 50;
 
 This also applies to calculations like `SELECT round(a, 2), a FROM ...` where
 `a` would be rounded and displayed as different values.
+
+## rnd_bin
+
+- `rnd_bin()` generates random binary data of a size up to `32` bytes.
+- `rnd_bin(minBytes, maxBytes, nullRate)` generates random binary data of a size
+  between `minBytes` and `maxBytes` and returns `null` at a rate defined by
+  `nullRate`.
+
+**Arguments:**
+
+- `minBytes` is a `long` defining the minimum size in bytes of a generated
+  binary (inclusive).
+- `maxBytes` is a `long` defining the maximum size in bytes of a generated
+  binary (inclusive).
+- `nullRate` is an `int` defining the frequency of occurrence of `null` values:
+  - `0`: No `null` will be returned.
+  - `1`: Will only return `null`.
+  - `N > 1`: On average, one in N generated values will be `null`.
+
+**Return value:**
+
+Return value type is `binary`.
+
+**Examples:**
+
+```questdb-sql title="Random binary"
+SELECT rnd_bin() FROM long_sequence(5);
+SELECT rnd_bin(2, 5, 2) FROM long_sequence(5);
+```
 
 ## rnd_boolean
 
@@ -145,35 +175,208 @@ SELECT rnd_byte(-1,1) FROM long_sequence(5);
 0,1,-1,-1,0
 ```
 
-## rnd_short
+## rnd_char
 
-- `rnd_short()` - returns a random integer which can take any value between
-  `-32768` and `32767`.
-- `rnd_short(min, max)` - returns short values in a specific range (for example
-  only positive, or between 1 and 10). Supplying `min` above `max` will result
-  in an `invalid range` error.
-
-**Arguments:**
-
-- `min`: is a `short` representing the lowest possible generated value
-  (inclusive).
-- `max`: is a `short` representing the highest possible generated value
-  (inclusive).
+- `rnd_char()` is used to generate a random `char` which will be an uppercase
+  character from the 26-letter A to Z alphabet. Letters from A to Z will be
+  generated with equal probability.
 
 **Return value:**
 
-Return value type is `short`.
+Return value type is `char`.
 
 **Examples:**
 
-```questdb-sql title="Random short"
-SELECT rnd_short() FROM long_sequence(5);
-SELECT rnd_short(-1,1) FROM long_sequence(5);
+```questdb-sql title="Random char"
+SELECT rnd_char() FROM long_sequence(5);
 ```
 
 ```
--27434,234,-12977,8843,24
-0,1,-1,-1,0
+G, P, E, W, K
+```
+
+## rnd_date
+
+- `rnd_date(start, end, nanRate)` - generates a random date between `start` and
+  `end` dates (both inclusive). It will also generate `NaN` values at a
+  frequency defined by `nanRate`. When `start` or `end` are invalid dates, or
+  when `start` is superior to `end`, it will return `invalid range` error. When
+  `nanRate` is inferior to 0, it will return `invalid NAN rate` error.
+
+**Arguments:**
+
+- `start` is a `date` defining the minimum possible generated date (inclusive)
+- `end` is a `date` defining the maximum possible generated date (inclusive)
+- `nanRate` defines the frequency of occurrence of `NaN` values:
+  - `0`: No `NaN` will be returned.
+  - `1`: Will only return `NaN`.
+  - `N > 1`: On average, one in N generated values will be NaN.
+
+**Return value:**
+
+Return value type is `date`.
+
+**Examples:**
+
+```questdb-sql title="Random date"
+SELECT rnd_date(
+    to_date('2015', 'yyyy'),
+    to_date('2016', 'yyyy'),
+    0)
+FROM long_sequence(5);
+```
+
+```
+2015-01-29T18:00:17.402Z, 2015-11-15T20:22:14.112Z,
+2015-12-08T09:26:04.483Z, 2015-05-28T02:22:47.022Z,
+2015-10-13T19:16:37.034Z
+```
+
+## rnd_decimal
+
+- `rnd_decimal(precision, scale, nanRate)` - generates a random **positive**
+  `decimal` between `0` and the maximum value representable by the given
+  precision and scale.
+
+**Arguments:**
+
+- `precision` is an `int` defining the total number of digits.
+- `scale` is an `int` defining the number of digits after the decimal point.
+- `nanRate` is an `int` defining the frequency of occurrence of `NaN` values:
+  - `0`: No `NaN` will be returned.
+  - `1`: Will only return `NaN`.
+  - `N > 1`: On average, one in N generated values will be `NaN`.
+
+**Return value:**
+
+Return value type is `decimal`.
+
+**Examples:**
+
+```questdb-sql title="Random decimal"
+SELECT rnd_decimal(8, 2, 0) FROM long_sequence(5);
+SELECT rnd_decimal(8, 2, 4) FROM long_sequence(5);
+```
+
+```
+6618.97 5037.02 7118.16 9024.15 537.05
+null 734.74 787.93 null 789.92
+```
+
+## rnd_double
+
+- `rnd_double()` - generates a random **positive** `double` between 0 and 1.
+- `rnd_double(nanRate)` - generates a random **positive** `double` between 0 and
+  1 which will be `NaN` at a frequency defined by `nanRate`.
+
+**Arguments:**
+
+- `nanRate` is an `int` defining the frequency of occurrence of `NaN` values:
+  - `0`: No `NaN` will be returned.
+  - `1`: Will only return `NaN`.
+  - `N > 1`: On average, one in N generated values will be `NaN`.
+
+**Return value:**
+
+Return value type is `double`.
+
+**Examples:**
+
+```questdb-sql title="Random double"
+SELECT rnd_double() FROM long_sequence(5);
+SELECT rnd_double(2) FROM long_sequence(5);
+```
+
+```
+0.99115364871, 0.31011470271, 0.10776479191, 0.53938281731, 0.89820403511
+0.99115364871, null, null, 0.53938281731, 0.89820403511
+```
+
+## rnd_double_array
+
+Generates a `double` array with random elements.
+
+- `rnd_double_array(nDims)` - generates an array with the specified
+  dimensionality, random dimension lengths (up to 16), and random elements.
+- `rnd_double_array(nDims, nanRate)` - same as above, with `NaN` values at the
+  specified rate.
+- `rnd_double_array(nDims, nanRate, maxDimLength)` - same as above, with a
+  custom maximum dimension length.
+- `rnd_double_array(nDims, nanRate, 0, dim1Len, dim2Len, ...)` - generates an
+  array of fixed size with random elements. The `0` is a placeholder needed to
+  disambiguate from other forms.
+
+**Arguments:**
+
+- `nDims` is an `int` specifying the number of dimensions.
+- `nanRate` is an `int` defining the frequency of `NaN` values (default: `0`):
+  - `0`: No `NaN` will be returned.
+  - `1`: Will only return `NaN`.
+  - `N > 1`: On average, one in N generated values will be `NaN`.
+- `maxDimLength` is an `int` specifying the maximum length of each dimension
+  (default: `16`).
+- `dim1Len, dim2Len, ...` are `int` values specifying exact lengths for each
+  dimension when using fixed-size form.
+
+**Return value:**
+
+Return value type is `double[]` (array).
+
+**Examples:**
+
+Generate a 2-dimensional array with 50% NaNs and max dimension length 2:
+
+```questdb-sql
+SELECT rnd_double_array(2, 2, 2);
+```
+
+```text
+[
+  [NaN, 0.45738551710910846],
+  [0.7702337472360304, NaN]
+]
+```
+
+Generate a random 2x5 array with no NaNs:
+
+```questdb-sql
+SELECT rnd_double_array(2, 0, 0, 2, 5);
+```
+
+```text
+[
+  [0.316129098879942,  0.8662158040337894, 0.8642568676265672,  0.6470407728977403, 0.4740048603478647],
+  [0.2928431722534959, 0.4269209916086062, 0.08520276767101154, 0.5371988206397026, 0.5786689751730609]
+]
+```
+
+## rnd_float
+
+- `rnd_float()` - generates a random **positive** `float` between 0 and 1.
+- `rnd_float(nanRate)` - generates a random **positive** `float` between 0 and 1
+  which will be `NaN` at a frequency defined by `nanRate`.
+
+**Arguments:**
+
+- `nanRate` is an `int` defining the frequency of occurrence of `NaN` values:
+  - `0`: No `NaN` will be returned.
+  - `1`: Will only return `NaN`.
+  - `N > 1`: On average, one in N generated values will be `NaN`.
+
+**Return value:**
+
+Return value type is `float`.
+
+**Examples:**
+
+```questdb-sql title="Random float"
+SELECT rnd_float() FROM long_sequence(5);
+SELECT rnd_float(2) FROM long_sequence(6);
+```
+
+```
+0.3821478, 0.5162148, 0.22929084, 0.03736937, 0.39675003
+0.08108246, 0.7082644, null, 0.6784522, null, 0.5711276
 ```
 
 ## rnd_int
@@ -213,6 +416,48 @@ SELECT rnd_int(1,4,2) FROM long_sequence(5);
 1,4,3,1,2
 null,null,null,null,null
 1,null,4,null,2
+```
+
+## rnd_ipv4
+
+- `rnd_ipv4()` - generates a random IPv4 address between `0.0.0.1` and
+  `255.255.255.255`.
+- `rnd_ipv4(subnet, nullRate)` - generates a random IPv4 address within the
+  bounds of a given subnet.
+
+**Arguments:**
+
+- `subnet` is a `string` defining the subnet in CIDR notation (e.g.,
+  `'192.168.1.0/24'`).
+- `nullRate` is an `int` defining the frequency of occurrence of `null` values:
+  - `0`: No `null` will be returned.
+  - `1`: Will only return `null`.
+  - `N > 1`: On average, one in N generated values will be `null`.
+
+**Return value:**
+
+Return value type is `ipv4`.
+
+**Examples:**
+
+```questdb-sql title="Random IPv4 address"
+SELECT rnd_ipv4() FROM long_sequence(3);
+```
+
+```
+97.29.14.22
+182.43.9.117
+45.192.88.3
+```
+
+```questdb-sql title="Random IPv4 within a subnet"
+SELECT rnd_ipv4('22.43.0.0/16', 0) FROM long_sequence(3);
+```
+
+```
+22.43.200.12
+22.43.55.189
+22.43.101.7
 ```
 
 ## rnd_long
@@ -276,210 +521,95 @@ SELECT rnd_long256() FROM long_sequence(5);
 0x7c80546eea2ec093a5244e39efad3f39c5489d2337007fd0b61d8b141058724d
 ```
 
-## rnd_float
+## rnd_short
 
-- `rnd_float()` - generates a random **positive** `float` between 0 and 1.
-- `rnd_float(nanRate)` - generates a random **positive** `float` between 0 and 1
-  which will be `NaN` at a frequency defined by `nanRate`.
-
-**Arguments:**
-
-- `nanRate` is an `int` defining the frequency of occurrence of `NaN` values:
-  - `0`: No `NaN` will be returned.
-  - `1`: Will only return `NaN`.
-  - `N > 1`: On average, one in N generated values will be `NaN`.
-
-**Return value:**
-
-Return value type is `float`.
-
-**Examples:**
-
-```questdb-sql title="Random float"
-SELECT rnd_float() FROM long_sequence(5);
-SELECT rnd_float(2) FROM long_sequence(6);
-```
-
-```
-0.3821478, 0.5162148, 0.22929084, 0.03736937, 0.39675003
-0.08108246, 0.7082644, null, 0.6784522, null, 0.5711276
-```
-
-## rnd_double
-
-- `rnd_double()` - generates a random **positive** `double` between 0 and 1.
-- `rnd_double(nanRate)` - generates a random **positive** `double` between 0 and
-  1 which will be `NaN` at a frequency defined by `nanRate`.
+- `rnd_short()` - returns a random integer which can take any value between
+  `-32768` and `32767`.
+- `rnd_short(min, max)` - returns short values in a specific range (for example
+  only positive, or between 1 and 10). Supplying `min` above `max` will result
+  in an `invalid range` error.
 
 **Arguments:**
 
-- `nanRate` is an `int` defining the frequency of occurrence of `NaN` values:
-  - `0`: No `NaN` will be returned.
-  - `1`: Will only return `NaN`.
-  - `N > 1`: On average, one in N generated values will be `NaN`.
+- `min`: is a `short` representing the lowest possible generated value
+  (inclusive).
+- `max`: is a `short` representing the highest possible generated value
+  (inclusive).
 
 **Return value:**
 
-Return value type is `double`.
+Return value type is `short`.
 
 **Examples:**
 
-```questdb-sql title="Random double"
-SELECT rnd_double() FROM long_sequence(5);
-SELECT rnd_double(2) FROM long_sequence(5);
+```questdb-sql title="Random short"
+SELECT rnd_short() FROM long_sequence(5);
+SELECT rnd_short(-1,1) FROM long_sequence(5);
 ```
 
 ```
-0.99115364871, 0.31011470271, 0.10776479191, 0.53938281731, 0.89820403511
-0.99115364871, null, null, 0.53938281731, 0.89820403511
+-27434,234,-12977,8843,24
+0,1,-1,-1,0
 ```
 
-## rnd_date
+## rnd_str
 
-- `rnd_date(start, end, nanRate)` - generates a random date between `start` and
-  `end` dates (both inclusive). It will also generate `NaN` values at a
-  frequency defined by `nanRate`. When `start` or `end` are invalid dates, or
-  when `start` is superior to `end`, it will return `invalid range` error. When
-  `nanRate` is inferior to 0, it will return `invalid NAN rate` error.
+- `rnd_str(stringList)` - chooses a random `string` from a list defined by the
+  user. It is useful when looking to generate specific strings from a finite
+  list (e.g., `BUY, SELL` or `AUTUMN, WINTER, SPRING, SUMMER`). Strings are
+  randomly chosen from the list with equal probability. When only one string is
+  provided in the list, this string will be chosen with 100% probability.
+- `rnd_str(minLength, maxLength, nullRate)` - generates strings of a length
+  between `minLength` and `maxLength` (both inclusive). The function will also
+  generate `null` values at a rate defined by `nullRate`.
+- `rnd_str(list_size, minLength, maxLength, nullRate)` - generates a finite list
+  of distinct random strings and chooses one string from the list at random.
 
 **Arguments:**
 
-- `start` is a `date` defining the minimum possible generated date (inclusive)
-- `end` is a `date` defining the maximum possible generated date (inclusive)
-- `nanRate` defines the frequency of occurrence of `NaN` values:
-  - `0`: No `NaN` will be returned.
-  - `1`: Will only return `NaN`.
-  - `N > 1`: On average, one in N generated values will be NaN.
+- `stringList` is a variable-length list of possible `string` values expressed
+  as a comma-separated list of strings. For example, `'a', 'bcd', 'efg123', '行'`
+- `list_size` is an optional `int` declaring the number of distinct `string`
+  values to generate.
+- `minLength` is an `int` defining the minimum length of a generated string
+  (inclusive).
+- `maxLength` is an `int` defining the maximum length of a generated string
+  (inclusive).
+- `nullRate` is an `int` defining the frequency of occurrence of `null` values:
+  - `0`: No `null` will be returned.
+  - `1`: Will only return `null`.
+  - `N > 1`: On average, one in N generated values will be `null`.
 
 **Return value:**
 
-Return value type is `date`.
+Return value type is `string`.
 
 **Examples:**
 
-```questdb-sql title="Random date"
-SELECT rnd_date(
-    to_date('2015', 'yyyy'),
-    to_date('2016', 'yyyy'),
-    0)
+```questdb-sql title="Random string from a list"
+SELECT rnd_str('ABC','def', '123')
 FROM long_sequence(5);
 ```
 
 ```
-2015-01-29T18:00:17.402Z, 2015-11-15T20:22:14.112Z,
-2015-12-08T09:26:04.483Z, 2015-05-28T02:22:47.022Z,
-2015-10-13T19:16:37.034Z
+'ABC', '123', 'def', '123', 'ABC'
 ```
 
-## rnd_timestamp
-
-- `rnd_timestamp(start, end, nanRate)` - generates a random timestamp between
-  `start` and `end` timestamps (both inclusive). It will also generate `NaN`
-  values at a frequency defined by `nanRate`. When `start` or `end` are invalid
-  timestamps, or when `start` is superior to `end`, it will return
-  `invalid range` error. When `nanRate` is inferior to 0, it will return
-  `invalid NAN rate` error.
-
-**Arguments:**
-
-- `start` is a `timestamp` defining the minimum possible generated timestamp
-  (inclusive)
-- `end` is a `timestamp` defining the maximum possible generated timestamp
-  (inclusive)
-- `nanRate` defines the frequency of occurrence of `NaN` values:
-  - `0`: No `NaN` will be returned.
-  - `1`: Will only return `NaN`.
-  - `N > 1`: On average, one in N generated values will be NaN.
-
-**Return value:**
-
-Return value type is `timestamp`.
-
-**Examples:**
-
-```questdb-sql title="Random timestamp"
-SELECT rnd_timestamp(
-    to_timestamp('2015', 'yyyy'),
-    to_timestamp('2016', 'yyyy'),
-    0)
-FROM long_sequence(5);
+```questdb-sql title="Random strings, including null, between min and max length."
+SELECT rnd_str(2, 2, 4)
+FROM long_sequence(8);
 ```
 
 ```
-2015-01-29T18:00:17.402762Z, 2015-11-15T20:22:14.112744Z,
-2015-12-08T09:26:04.483039Z, 2015-05-28T02:22:47.022680Z,
-2015-10-13T19:16:37.034203Z
+'AB', 'CD', null, 'EF', 'CD', 'EF', null, 'AB'
 ```
 
-:::tip
-
-To generate increasing timestamps, refer to the page about
-[row generators](/docs/query/functions/row-generator/).
-
-:::
-
-## rnd_timestamp_ns
-
-- `rnd_timestamp_ns(start, end, nanRate)` - generates a random nanosecond
-  timestamp between `start` and `end` timestamps (both inclusive). It will also
-  generate `NaN` values at a frequency defined by `nanRate`. When `start` or
-  `end` are invalid timestamps, or when `start` is superior to `end`, it will
-  return `invalid range` error. When `nanRate` is inferior to 0, it will return
-  `invalid NAN rate` error.
-
-This function is identical to [`rnd_timestamp`](#rnd_timestamp) but returns
-`timestamp_ns` (nanosecond resolution) instead of `timestamp` (microsecond
-resolution).
-
-**Arguments:**
-
-- `start` is a `timestamp` defining the minimum possible generated timestamp
-  (inclusive)
-- `end` is a `timestamp` defining the maximum possible generated timestamp
-  (inclusive)
-- `nanRate` defines the frequency of occurrence of `NaN` values:
-  - `0`: No `NaN` will be returned.
-  - `1`: Will only return `NaN`.
-  - `N > 1`: On average, one in N generated values will be NaN.
-
-**Return value:**
-
-Return value type is `timestamp_ns`.
-
-**Examples:**
-
-```questdb-sql title="Random nanosecond timestamp"
-SELECT rnd_timestamp_ns(
-    to_timestamp('2015', 'yyyy'),
-    to_timestamp('2016', 'yyyy'),
-    0)
-FROM long_sequence(5);
+```questdb-sql title="5 strings from a set of 3 distinct strings, each 2 characters long, no nulls."
+SELECT rnd_str(3, 2, 2, 0) FROM long_sequence(5);
 ```
 
 ```
-2015-01-29T18:00:17.402762123Z, 2015-11-15T20:22:14.112744456Z,
-2015-12-08T09:26:04.483039789Z, 2015-05-28T02:22:47.022680012Z,
-2015-10-13T19:16:37.034203345Z
-```
-
-## rnd_char
-
-- `rnd_char()` is used to generate a random `char` which will be an uppercase
-  character from the 26-letter A to Z alphabet. Letters from A to Z will be
-  generated with equal probability.
-
-**Return value:**
-
-Return value type is `char`.
-
-**Examples:**
-
-```questdb-sql title="Random char"
-SELECT rnd_char() FROM long_sequence(5);
-```
-
-```
-G, P, E, W, K
+'DS', 'GG', 'XS', 'GG', 'XS'
 ```
 
 ## rnd_symbol
@@ -534,6 +664,60 @@ FROM long_sequence(5);
 ```
 'ABC', 'DEFG', 'ABC', 'DEFG', 'DEFG'
 ```
+
+## rnd_symbol_weighted
+
+Generates random symbols with explicit weights. Each symbol is paired with a
+weight that determines its relative probability of being selected.
+
+- `rnd_symbol_weighted(symbol1, weight1, symbol2, weight2, ...)` - takes
+  symbol-weight pairs. Weights are relative, so `('A', 50, 'B', 50)` and
+  `('A', 1, 'B', 1)` produce the same 50/50 distribution.
+
+**Arguments:**
+
+- Arguments must be provided in pairs: a symbol followed by its weight.
+- `symbol` is a `string` or `symbol` value.
+- `weight` is a non-negative number (`int` or `double`) representing the
+  relative weight. A weight of `0` means the symbol will never be selected.
+
+**Return value:**
+
+Return value type is `symbol`.
+
+**Examples:**
+
+```questdb-sql title="Weighted symbol distribution"
+SELECT rnd_symbol_weighted('AAPL', 50, 'MSFT', 30, 'GOOGL', 15, 'TSLA', 5) AS ticker
+FROM long_sequence(5);
+```
+
+```
+AAPL
+MSFT
+AAPL
+AAPL
+GOOGL
+```
+
+```questdb-sql title="Verify weighted distribution"
+SELECT
+    ticker,
+    count() AS cnt
+FROM (
+    SELECT rnd_symbol_weighted('AAPL', 50, 'MSFT', 30, 'GOOGL', 15, 'TSLA', 5) AS ticker
+    FROM long_sequence(100000)
+)
+GROUP BY ticker
+ORDER BY cnt DESC;
+```
+
+| ticker | cnt   |
+| ------ | ----- |
+| AAPL   | 50021 |
+| MSFT   | 29894 |
+| GOOGL  | 15052 |
+| TSLA   | 5033  |
 
 ## rnd_symbol_zipf
 
@@ -627,59 +811,123 @@ S1
 S0
 ```
 
-## rnd_symbol_weighted
+## rnd_timestamp
 
-Generates random symbols with explicit weights. Each symbol is paired with a
-weight that determines its relative probability of being selected.
-
-- `rnd_symbol_weighted(symbol1, weight1, symbol2, weight2, ...)` - takes
-  symbol-weight pairs. Weights are relative, so `('A', 50, 'B', 50)` and
-  `('A', 1, 'B', 1)` produce the same 50/50 distribution.
+- `rnd_timestamp(start, end, nanRate)` - generates a random timestamp between
+  `start` and `end` timestamps (both inclusive). It will also generate `NaN`
+  values at a frequency defined by `nanRate`. When `start` or `end` are invalid
+  timestamps, or when `start` is superior to `end`, it will return
+  `invalid range` error. When `nanRate` is inferior to 0, it will return
+  `invalid NAN rate` error.
 
 **Arguments:**
 
-- Arguments must be provided in pairs: a symbol followed by its weight.
-- `symbol` is a `string` or `symbol` value.
-- `weight` is a non-negative number (`int` or `double`) representing the
-  relative weight. A weight of `0` means the symbol will never be selected.
+- `start` is a `timestamp` defining the minimum possible generated timestamp
+  (inclusive)
+- `end` is a `timestamp` defining the maximum possible generated timestamp
+  (inclusive)
+- `nanRate` defines the frequency of occurrence of `NaN` values:
+  - `0`: No `NaN` will be returned.
+  - `1`: Will only return `NaN`.
+  - `N > 1`: On average, one in N generated values will be NaN.
 
 **Return value:**
 
-Return value type is `symbol`.
+Return value type is `timestamp`.
 
 **Examples:**
 
-```questdb-sql title="Weighted symbol distribution"
-SELECT rnd_symbol_weighted('AAPL', 50, 'MSFT', 30, 'GOOGL', 15, 'TSLA', 5) AS ticker
+```questdb-sql title="Random timestamp"
+SELECT rnd_timestamp(
+    to_timestamp('2015', 'yyyy'),
+    to_timestamp('2016', 'yyyy'),
+    0)
 FROM long_sequence(5);
 ```
 
 ```
-AAPL
-MSFT
-AAPL
-AAPL
-GOOGL
+2015-01-29T18:00:17.402762Z, 2015-11-15T20:22:14.112744Z,
+2015-12-08T09:26:04.483039Z, 2015-05-28T02:22:47.022680Z,
+2015-10-13T19:16:37.034203Z
 ```
 
-```questdb-sql title="Verify weighted distribution"
-SELECT
-    ticker,
-    count() AS cnt
-FROM (
-    SELECT rnd_symbol_weighted('AAPL', 50, 'MSFT', 30, 'GOOGL', 15, 'TSLA', 5) AS ticker
-    FROM long_sequence(100000)
-)
-GROUP BY ticker
-ORDER BY cnt DESC;
+:::tip
+
+To generate increasing timestamps, refer to the page about
+[row generators](/docs/query/functions/row-generator/).
+
+:::
+
+## rnd_timestamp_ns
+
+- `rnd_timestamp_ns(start, end, nanRate)` - generates a random nanosecond
+  timestamp between `start` and `end` timestamps (both inclusive). It will also
+  generate `NaN` values at a frequency defined by `nanRate`. When `start` or
+  `end` are invalid timestamps, or when `start` is superior to `end`, it will
+  return `invalid range` error. When `nanRate` is inferior to 0, it will return
+  `invalid NAN rate` error.
+
+This function is identical to [`rnd_timestamp`](#rnd_timestamp) but returns
+`timestamp_ns` (nanosecond resolution) instead of `timestamp` (microsecond
+resolution).
+
+**Arguments:**
+
+- `start` is a `timestamp` defining the minimum possible generated timestamp
+  (inclusive)
+- `end` is a `timestamp` defining the maximum possible generated timestamp
+  (inclusive)
+- `nanRate` defines the frequency of occurrence of `NaN` values:
+  - `0`: No `NaN` will be returned.
+  - `1`: Will only return `NaN`.
+  - `N > 1`: On average, one in N generated values will be NaN.
+
+**Return value:**
+
+Return value type is `timestamp_ns`.
+
+**Examples:**
+
+```questdb-sql title="Random nanosecond timestamp"
+SELECT rnd_timestamp_ns(
+    to_timestamp('2015', 'yyyy'),
+    to_timestamp('2016', 'yyyy'),
+    0)
+FROM long_sequence(5);
 ```
 
-| ticker | cnt   |
-| ------ | ----- |
-| AAPL   | 50021 |
-| MSFT   | 29894 |
-| GOOGL  | 15052 |
-| TSLA   | 5033  |
+```
+2015-01-29T18:00:17.402762123Z, 2015-11-15T20:22:14.112744456Z,
+2015-12-08T09:26:04.483039789Z, 2015-05-28T02:22:47.022680012Z,
+2015-10-13T19:16:37.034203345Z
+```
+
+## rnd_uuid4
+
+- `rnd_uuid4()` is used to generate a random
+  [UUID](/docs/query/datatypes/overview/#the-uuid-type).
+- The generated UUIDs are
+  [version 4](<https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)>)
+  as per the [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.4)
+  specification.
+- Generated UUIDs do not use a cryptographically strong random generator and
+  should not be used for security purposes.
+
+**Return value:**
+
+Return value type is `uuid`.
+
+**Examples:**
+
+```questdb-sql title="Random UUID"
+SELECT rnd_uuid4() FROM long_sequence(3);
+```
+
+```
+deca0b0b-b14b-4d39-b891-9e1e786a48e7
+2f113ebb-d36e-4e58-b804-6ece2263abe4
+6eddd24a-8889-4345-8001-822cc2d41951
+```
 
 ## rnd_varchar
 
@@ -728,251 +976,4 @@ FROM long_sequence(4);
 
 ```text
 '潃', 'Ԓ㠗', '콻薓', '8>'
-```
-
-## rnd_str
-
-- `rnd_str(stringList)` - chooses a random `string` from a list defined by the
-  user. It is useful when looking to generate specific strings from a finite
-  list (e.g., `BUY, SELL` or `AUTUMN, WINTER, SPRING, SUMMER`). Strings are
-  randomly chosen from the list with equal probability. When only one string is
-  provided in the list, this string will be chosen with 100% probability.
-- `rnd_str(minLength, maxLength, nullRate)` - generates strings of a length
-  between `minLength` and `maxLength` (both inclusive). The function will also
-  generate `null` values at a rate defined by `nullRate`.
-- `rnd_str(list_size, minLength, maxLength, nullRate)` - generates a finite list
-  of distinct random strings and chooses one string from the list at random.
-
-**Arguments:**
-
-- `stringList` is a variable-length list of possible `string` values expressed
-  as a comma-separated list of strings. For example, `'a', 'bcd', 'efg123', '行'`
-- `list_size` is an optional `int` declaring the number of distinct `string`
-  values to generate.
-- `minLength` is an `int` defining the minimum length of a generated string
-  (inclusive).
-- `maxLength` is an `int` defining the maximum length of a generated string
-  (inclusive).
-- `nullRate` is an `int` defining the frequency of occurrence of `null` values:
-  - `0`: No `null` will be returned.
-  - `1`: Will only return `null`.
-  - `N > 1`: On average, one in N generated values will be `null`.
-
-**Return value:**
-
-Return value type is `string`.
-
-**Examples:**
-
-```questdb-sql title="Random string from a list"
-SELECT rnd_str('ABC','def', '123')
-FROM long_sequence(5);
-```
-
-```
-'ABC', '123', 'def', '123', 'ABC'
-```
-
-```questdb-sql title="Random strings, including null, between min and max length."
-SELECT rnd_str(2, 2, 4)
-FROM long_sequence(8);
-```
-
-```
-'AB', 'CD', null, 'EF', 'CD', 'EF', null, 'AB'
-```
-
-```questdb-sql title="5 strings from a set of 3 distinct strings, each 2 characters long, no nulls."
-SELECT rnd_str(3, 2, 2, 0) FROM long_sequence(5);
-```
-
-```
-'DS', 'GG', 'XS', 'GG', 'XS'
-```
-
-## rnd_bin
-
-- `rnd_bin()` generates random binary data of a size up to `32` bytes.
-- `rnd_bin(minBytes, maxBytes, nullRate)` generates random binary data of a size
-  between `minBytes` and `maxBytes` and returns `null` at a rate defined by
-  `nullRate`.
-
-**Arguments:**
-
-- `minBytes` is a `long` defining the minimum size in bytes of a generated
-  binary (inclusive).
-- `maxBytes` is a `long` defining the maximum size in bytes of a generated
-  binary (inclusive).
-- `nullRate` is an `int` defining the frequency of occurrence of `null` values:
-  - `0`: No `null` will be returned.
-  - `1`: Will only return `null`.
-  - `N > 1`: On average, one in N generated values will be `null`.
-
-**Return value:**
-
-Return value type is `binary`.
-
-**Examples:**
-
-```questdb-sql title="Random binary"
-SELECT rnd_bin() FROM long_sequence(5);
-SELECT rnd_bin(2, 5, 2) FROM long_sequence(5);
-```
-
-## rnd_uuid4
-
-- `rnd_uuid4()` is used to generate a random
-  [UUID](/docs/query/datatypes/overview/#the-uuid-type).
-- The generated UUIDs are
-  [version 4](<https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)>)
-  as per the [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.4)
-  specification.
-- Generated UUIDs do not use a cryptographically strong random generator and
-  should not be used for security purposes.
-
-**Return value:**
-
-Return value type is `uuid`.
-
-**Examples:**
-
-```questdb-sql title="Random UUID"
-SELECT rnd_uuid4() FROM long_sequence(3);
-```
-
-```
-deca0b0b-b14b-4d39-b891-9e1e786a48e7
-2f113ebb-d36e-4e58-b804-6ece2263abe4
-6eddd24a-8889-4345-8001-822cc2d41951
-```
-
-## rnd_ipv4
-
-- `rnd_ipv4()` - generates a random IPv4 address between `0.0.0.1` and
-  `255.255.255.255`.
-- `rnd_ipv4(subnet, nullRate)` - generates a random IPv4 address within the
-  bounds of a given subnet.
-
-**Arguments:**
-
-- `subnet` is a `string` defining the subnet in CIDR notation (e.g.,
-  `'192.168.1.0/24'`).
-- `nullRate` is an `int` defining the frequency of occurrence of `null` values:
-  - `0`: No `null` will be returned.
-  - `1`: Will only return `null`.
-  - `N > 1`: On average, one in N generated values will be `null`.
-
-**Return value:**
-
-Return value type is `ipv4`.
-
-**Examples:**
-
-```questdb-sql title="Random IPv4 address"
-SELECT rnd_ipv4() FROM long_sequence(3);
-```
-
-```
-97.29.14.22
-182.43.9.117
-45.192.88.3
-```
-
-```questdb-sql title="Random IPv4 within a subnet"
-SELECT rnd_ipv4('22.43.0.0/16', 0) FROM long_sequence(3);
-```
-
-```
-22.43.200.12
-22.43.55.189
-22.43.101.7
-```
-
-## rnd_double_array
-
-Generates a `double` array with random elements.
-
-- `rnd_double_array(nDims)` - generates an array with the specified
-  dimensionality, random dimension lengths (up to 16), and random elements.
-- `rnd_double_array(nDims, nanRate)` - same as above, with `NaN` values at the
-  specified rate.
-- `rnd_double_array(nDims, nanRate, maxDimLength)` - same as above, with a
-  custom maximum dimension length.
-- `rnd_double_array(nDims, nanRate, 0, dim1Len, dim2Len, ...)` - generates an
-  array of fixed size with random elements. The `0` is a placeholder needed to
-  disambiguate from other forms.
-
-**Arguments:**
-
-- `nDims` is an `int` specifying the number of dimensions.
-- `nanRate` is an `int` defining the frequency of `NaN` values (default: `0`):
-  - `0`: No `NaN` will be returned.
-  - `1`: Will only return `NaN`.
-  - `N > 1`: On average, one in N generated values will be `NaN`.
-- `maxDimLength` is an `int` specifying the maximum length of each dimension
-  (default: `16`).
-- `dim1Len, dim2Len, ...` are `int` values specifying exact lengths for each
-  dimension when using fixed-size form.
-
-**Return value:**
-
-Return value type is `double[]` (array).
-
-**Examples:**
-
-Generate a 2-dimensional array with 50% NaNs and max dimension length 2:
-
-```questdb-sql
-SELECT rnd_double_array(2, 2, 2);
-```
-
-```text
-[
-  [NaN, 0.45738551710910846],
-  [0.7702337472360304, NaN]
-]
-```
-
-Generate a random 2x5 array with no NaNs:
-
-```questdb-sql
-SELECT rnd_double_array(2, 0, 0, 2, 5);
-```
-
-```text
-[
-  [0.316129098879942,  0.8662158040337894, 0.8642568676265672,  0.6470407728977403, 0.4740048603478647],
-  [0.2928431722534959, 0.4269209916086062, 0.08520276767101154, 0.5371988206397026, 0.5786689751730609]
-]
-```
-
-## rnd_decimal
-
-- `rnd_decimal(precision, scale, nanRate)` - generates a random **positive**
-  `decimal` between `0` and the maximum value representable by the given
-  precision and scale.
-
-**Arguments:**
-
-- `precision` is an `int` defining the total number of digits.
-- `scale` is an `int` defining the number of digits after the decimal point.
-- `nanRate` is an `int` defining the frequency of occurrence of `NaN` values:
-  - `0`: No `NaN` will be returned.
-  - `1`: Will only return `NaN`.
-  - `N > 1`: On average, one in N generated values will be `NaN`.
-
-**Return value:**
-
-Return value type is `decimal`.
-
-**Examples:**
-
-```questdb-sql title="Random decimal"
-SELECT rnd_decimal(8, 2, 0) FROM long_sequence(5);
-SELECT rnd_decimal(8, 2, 4) FROM long_sequence(5);
-```
-
-```
-6618.97 5037.02 7118.16 9024.15 537.05
-null 734.74 787.93 null 789.92
 ```

--- a/documentation/query/functions/row-generator.md
+++ b/documentation/query/functions/row-generator.md
@@ -14,7 +14,8 @@ to populate tables with test data.
 |----------|-------------|---------|
 | `long_sequence(n)` | You need exactly N rows | Generate 1 million test records |
 | `generate_series(start, end, step)` | You need values in a specific range | Generate hourly timestamps for January 2025 |
-| `timestamp_sequence(start, step)` | You need timestamps with `long_sequence` (supports random steps) | Generate N rows with varying intervals |
+| `timestamp_sequence(start, step)` | You need microsecond timestamps with `long_sequence` (supports random steps) | Generate N rows with varying intervals |
+| `timestamp_sequence_ns(start, step)` | You need nanosecond timestamps with `long_sequence` | Generate N rows with nanosecond precision |
 
 **Key difference for timestamps:**
 - `generate_series` is standalone and range-based: "give me timestamps from A to B"
@@ -22,90 +23,10 @@ to populate tables with test data.
 
 ## Function reference
 
-- [long_sequence](#long_sequence) - generate N rows for use with random functions
 - [generate_series](#generate_series) - generate arithmetic series (long, double, or timestamp)
-- [timestamp_sequence](#timestamp_sequence) - generate monotonically increasing timestamps
-
-## long_sequence
-
-Generates a pseudo-table with a specified number of rows. This is the primary
-function for creating test data in QuestDB.
-
-- `long_sequence(num_rows)` - generates rows with a random seed.
-- `long_sequence(num_rows, seed1, seed2)` - generates rows deterministically
-  using the provided seed values.
-
-The function serves two purposes:
-
-1. Generates a pseudo-table with an ascending series of `LONG` numbers starting
-   at 1 (accessible via column `x`)
-2. Provides the seed for pseudo-randomness to all
-   [random value functions](/docs/query/functions/random-value-generator/)
-
-:::tip
-
-Deterministic procedural generation makes it easy to test on vast amounts of
-data without moving large files across machines. Using the same seed on any
-machine at any time will consistently produce the same results for all random
-functions.
-
-:::
-
-**Arguments:**
-
-- `num_rows` is a `long` representing the number of rows to generate.
-- `seed1` and `seed2` are `long` numbers that combine into a `long128` seed for
-  deterministic generation.
-
-**Return value:**
-
-Returns a pseudo-table with a single column `x` of type `long`, containing
-values from 1 to `num_rows`.
-
-**Examples:**
-
-```questdb-sql title="Generate rows with random values"
-SELECT x, rnd_double()
-FROM long_sequence(5);
-```
-
-| x   | rnd_double   |
-| --- | ------------ |
-| 1   | 0.3279246687 |
-| 2   | 0.8341038236 |
-| 3   | 0.1023834675 |
-| 4   | 0.9130602021 |
-| 5   | 0.718276777  |
-
-```questdb-sql title="Access row number using the x column"
-SELECT x, x * x AS square
-FROM long_sequence(5);
-```
-
-| x   | square |
-| --- | ------ |
-| 1   | 1      |
-| 2   | 4      |
-| 3   | 9      |
-| 4   | 16     |
-| 5   | 25     |
-
-```questdb-sql title="Deterministic generation with fixed seed"
-SELECT rnd_double()
-FROM long_sequence(2, 128349234, 4327897);
-```
-
-:::note
-
-The results below will be the same on any machine at any time as long as they
-use the same seed in `long_sequence`.
-
-:::
-
-| rnd_double         |
-| ------------------ |
-| 0.8251337821991485 |
-| 0.2714941145110299 |
+- [long_sequence](#long_sequence) - generate N rows for use with random functions
+- [timestamp_sequence](#timestamp_sequence) - generate monotonically increasing microsecond timestamps
+- [timestamp_sequence_ns](#timestamp_sequence_ns) - generate monotonically increasing nanosecond timestamps
 
 ## generate_series
 
@@ -281,11 +202,94 @@ generate_series(
 | 2025-01-01T00:00:00.000000500Z |
 | 2025-01-01T00:00:00.000001000Z |
 
+## long_sequence
+
+Generates a pseudo-table with a specified number of rows. This is the primary
+function for creating test data in QuestDB.
+
+- `long_sequence(num_rows)` - generates rows with a random seed.
+- `long_sequence(num_rows, seed1, seed2)` - generates rows deterministically
+  using the provided seed values.
+
+The function serves two purposes:
+
+1. Generates a pseudo-table with an ascending series of `LONG` numbers starting
+   at 1 (accessible via column `x`)
+2. Provides the seed for pseudo-randomness to all
+   [random value functions](/docs/query/functions/random-value-generator/)
+
+:::tip
+
+Deterministic procedural generation makes it easy to test on vast amounts of
+data without moving large files across machines. Using the same seed on any
+machine at any time will consistently produce the same results for all random
+functions.
+
+:::
+
+**Arguments:**
+
+- `num_rows` is a `long` representing the number of rows to generate.
+- `seed1` and `seed2` are `long` numbers that combine into a `long128` seed for
+  deterministic generation.
+
+**Return value:**
+
+Returns a pseudo-table with a single column `x` of type `long`, containing
+values from 1 to `num_rows`.
+
+**Examples:**
+
+```questdb-sql title="Generate rows with random values"
+SELECT x, rnd_double()
+FROM long_sequence(5);
+```
+
+| x   | rnd_double   |
+| --- | ------------ |
+| 1   | 0.3279246687 |
+| 2   | 0.8341038236 |
+| 3   | 0.1023834675 |
+| 4   | 0.9130602021 |
+| 5   | 0.718276777  |
+
+```questdb-sql title="Access row number using the x column"
+SELECT x, x * x AS square
+FROM long_sequence(5);
+```
+
+| x   | square |
+| --- | ------ |
+| 1   | 1      |
+| 2   | 4      |
+| 3   | 9      |
+| 4   | 16     |
+| 5   | 25     |
+
+```questdb-sql title="Deterministic generation with fixed seed"
+SELECT rnd_double()
+FROM long_sequence(2, 128349234, 4327897);
+```
+
+:::note
+
+The results below will be the same on any machine at any time as long as they
+use the same seed in `long_sequence`.
+
+:::
+
+| rnd_double         |
+| ------------------ |
+| 0.8251337821991485 |
+| 0.2714941145110299 |
+
 ## timestamp_sequence
 
-Generates monotonically increasing timestamps when used with `long_sequence()`.
-Unlike `generate_series`, this function generates a single value per row and
-requires `long_sequence()` to produce multiple rows.
+Generates monotonically increasing microsecond timestamps when used with
+`long_sequence()`. Unlike `generate_series`, this function generates a single
+value per row and requires `long_sequence()` to produce multiple rows.
+
+For nanosecond timestamps, use [`timestamp_sequence_ns`](#timestamp_sequence_ns).
 
 - `timestamp_sequence(startTimestamp, step)` - generates timestamps starting at
   `startTimestamp`, incrementing by `step` microseconds per row.
@@ -302,8 +306,8 @@ The `step` can be:
 
 **Return value:**
 
-Return type is `TIMESTAMP`. If a `TIMESTAMP_NS` or a date literal with
-nanosecond resolution is provided, the return type is `TIMESTAMP_NS`.
+Return type is always `TIMESTAMP` (microsecond resolution), regardless of the
+input type.
 
 **Examples:**
 
@@ -338,3 +342,45 @@ FROM long_sequence(5);
 | 3   | 2019-10-17T00:00:00.600000Z |
 | 4   | 2019-10-17T00:00:00.900000Z |
 | 5   | 2019-10-17T00:00:01.300000Z |
+
+## timestamp_sequence_ns
+
+Generates monotonically increasing nanosecond timestamps when used with
+`long_sequence()`. This is the nanosecond counterpart of
+[`timestamp_sequence`](#timestamp_sequence).
+
+- `timestamp_sequence_ns(startTimestamp, step)` - generates timestamps starting
+  at `startTimestamp`, incrementing by `step` nanoseconds per row.
+
+The `step` can be:
+- A fixed value, resulting in evenly-spaced timestamps
+- A random function invocation, resulting in timestamps that grow by random
+  intervals
+
+**Arguments:**
+
+- `startTimestamp` is the starting (lowest) timestamp in the sequence. Use
+  `to_timestamp_ns()` to create a nanosecond-resolution start value.
+- `step` is the interval in nanoseconds between consecutive timestamps.
+
+**Return value:**
+
+Return type is always `TIMESTAMP_NS` (nanosecond resolution).
+
+**Examples:**
+
+```questdb-sql title="Nanosecond timestamps (100ns apart)"
+SELECT x, timestamp_sequence_ns(
+    to_timestamp_ns('2019-10-17T00:00:00', 'yyyy-MM-ddTHH:mm:ss'),
+    100L -- 100 nanoseconds
+) AS ts
+FROM long_sequence(5);
+```
+
+| x   | ts                                 |
+| --- | ---------------------------------- |
+| 1   | 2019-10-17T00:00:00.000000000Z     |
+| 2   | 2019-10-17T00:00:00.000000100Z     |
+| 3   | 2019-10-17T00:00:00.000000200Z     |
+| 4   | 2019-10-17T00:00:00.000000300Z     |
+| 5   | 2019-10-17T00:00:00.000000400Z     |

--- a/documentation/query/functions/spatial.md
+++ b/documentation/query/functions/spatial.md
@@ -240,72 +240,6 @@ INSERT INTO vehicle_positions VALUES
   ('2024-01-15T10:00:20Z', 'truck-1', 51.5350, -0.0890, 40);
 ```
 
-### geo_within_radius_latlon
-
-`geo_within_radius_latlon(lat, lon, center_lat, center_lon, radius_meters)` -
-Returns `true` if a geographic point lies within a specified distance from a
-center point (inclusive).
-
-Use this function for proximity queries on GPS data, location-based filtering,
-and geographic area searches.
-
-**Arguments:**
-
-- `lat` - Latitude of the point to test in degrees (-90 to 90)
-- `lon` - Longitude of the point to test in degrees (-180 to 180)
-- `center_lat` - Latitude of the center point in degrees (-90 to 90)
-- `center_lon` - Longitude of the center point in degrees (-180 to 180)
-- `radius_meters` - Radius in meters (double). Must be non-negative.
-
-**Return value:**
-
-Returns `boolean`:
-
-- `true` if the point is within the specified distance
-- `false` if the point is outside the radius
-- `NULL` if any argument is `NULL`
-
-Invalid inputs (coordinates out of range, `NaN`, or negative radius) produce an
-error.
-
-**Examples:**
-
-```questdb-sql title="Find vehicle positions within 500m of a depot"
-SELECT ts, vehicle_id, lat, lon
-FROM vehicle_positions
-WHERE geo_within_radius_latlon(lat, lon, 51.5074, -0.1278, 500);
-```
-
-| ts                          | vehicle_id | lat     | lon     |
-| :-------------------------- | :--------- | :------ | :------ |
-| 2024-01-15T10:00:00.000000Z | truck-1    | 51.5074 | -0.1278 |
-| 2024-01-15T10:00:05.000000Z | truck-1    | 51.5095 | -0.1245 |
-| 2024-01-15T10:00:10.000000Z | truck-1    | 51.5120 | -0.1190 |
-
-```questdb-sql title="Lookup positions by service area name"
-CREATE TABLE service_areas (
-  area_name SYMBOL,
-  center_lat DOUBLE,
-  center_lon DOUBLE,
-  radius_m DOUBLE
-);
-
-INSERT INTO service_areas VALUES
-  ('central_london', 51.5074, -0.1278, 1000),
-  ('kings_cross', 51.5320, -0.1240, 800);
-
-SELECT v.ts, v.vehicle_id, v.lat, v.lon
-FROM vehicle_positions v
-JOIN service_areas a ON geo_within_radius_latlon(v.lat, v.lon, a.center_lat, a.center_lon, a.radius_m)
-WHERE a.area_name = 'central_london';
-```
-
-| ts                          | vehicle_id | lat     | lon     |
-| :-------------------------- | :--------- | :------ | :------ |
-| 2024-01-15T10:00:00.000000Z | truck-1    | 51.5074 | -0.1278 |
-| 2024-01-15T10:00:05.000000Z | truck-1    | 51.5095 | -0.1245 |
-| 2024-01-15T10:00:10.000000Z | truck-1    | 51.5120 | -0.1190 |
-
 ### geo_distance_meters
 
 `geo_distance_meters(lat1, lon1, lat2, lon2)` - Calculates the distance in
@@ -375,42 +309,78 @@ JOIN depots d ON d.depot_name = 'east_depot';
 | 2024-01-15T10:00:15.000000Z | truck-1    | 1567       |
 | 2024-01-15T10:00:20.000000Z | truck-1    | 1456       |
 
+### geo_within_radius_latlon
+
+`geo_within_radius_latlon(lat, lon, center_lat, center_lon, radius_meters)` -
+Returns `true` if a geographic point lies within a specified distance from a
+center point (inclusive).
+
+Use this function for proximity queries on GPS data, location-based filtering,
+and geographic area searches.
+
+**Arguments:**
+
+- `lat` - Latitude of the point to test in degrees (-90 to 90)
+- `lon` - Longitude of the point to test in degrees (-180 to 180)
+- `center_lat` - Latitude of the center point in degrees (-90 to 90)
+- `center_lon` - Longitude of the center point in degrees (-180 to 180)
+- `radius_meters` - Radius in meters (double). Must be non-negative.
+
+**Return value:**
+
+Returns `boolean`:
+
+- `true` if the point is within the specified distance
+- `false` if the point is outside the radius
+- `NULL` if any argument is `NULL`
+
+Invalid inputs (coordinates out of range, `NaN`, or negative radius) produce an
+error.
+
+**Examples:**
+
+```questdb-sql title="Find vehicle positions within 500m of a depot"
+SELECT ts, vehicle_id, lat, lon
+FROM vehicle_positions
+WHERE geo_within_radius_latlon(lat, lon, 51.5074, -0.1278, 500);
+```
+
+| ts                          | vehicle_id | lat     | lon     |
+| :-------------------------- | :--------- | :------ | :------ |
+| 2024-01-15T10:00:00.000000Z | truck-1    | 51.5074 | -0.1278 |
+| 2024-01-15T10:00:05.000000Z | truck-1    | 51.5095 | -0.1245 |
+| 2024-01-15T10:00:10.000000Z | truck-1    | 51.5120 | -0.1190 |
+
+```questdb-sql title="Lookup positions by service area name"
+CREATE TABLE service_areas (
+  area_name SYMBOL,
+  center_lat DOUBLE,
+  center_lon DOUBLE,
+  radius_m DOUBLE
+);
+
+INSERT INTO service_areas VALUES
+  ('central_london', 51.5074, -0.1278, 1000),
+  ('kings_cross', 51.5320, -0.1240, 800);
+
+SELECT v.ts, v.vehicle_id, v.lat, v.lon
+FROM vehicle_positions v
+JOIN service_areas a ON geo_within_radius_latlon(v.lat, v.lon, a.center_lat, a.center_lon, a.radius_m)
+WHERE a.area_name = 'central_london';
+```
+
+| ts                          | vehicle_id | lat     | lon     |
+| :-------------------------- | :--------- | :------ | :------ |
+| 2024-01-15T10:00:00.000000Z | truck-1    | 51.5074 | -0.1278 |
+| 2024-01-15T10:00:05.000000Z | truck-1    | 51.5095 | -0.1245 |
+| 2024-01-15T10:00:10.000000Z | truck-1    | 51.5120 | -0.1190 |
+
 ## Geohash functions
 
 Geohash functions encode geographic coordinates into compact string
 representations suitable for indexing. For comprehensive geohash documentation,
 see the [geohashes data type](/docs/query/datatypes/geohashes/) and
 [spatial operators](/docs/query/operators/spatial/).
-
-### rnd_geohash
-
-`rnd_geohash(bits)` - Returns a random geohash of variable precision.
-
-**Arguments:**
-
-- `bits` - An integer between `1` and `60` which determines the precision of the
-  generated geohash
-
-**Return value:**
-
-Returns a `geohash`.
-
-**Examples:**
-
-```questdb-sql title="Generate random geohashes of various precisions"
-SELECT
-    rnd_geohash(7) AS g7,
-    rnd_geohash(10) AS g10,
-    rnd_geohash(30) AS g30,
-    rnd_geohash(60) AS g60
-FROM long_sequence(3);
-```
-
-| g7      | g10 | g30    | g60          |
-| :------ | :-- | :----- | :----------- |
-| 1101100 | 4h  | hsmmq8 | rjtwedd0z72p |
-| 0010011 | vf  | f9jc1q | fzj09w97tj1h |
-| 0101011 | kx  | fkhked | v4cs8qsnjkeh |
 
 ### make_geohash
 
@@ -454,6 +424,36 @@ SELECT
     make_geohash(lon, lat, 30) AS geohash
 FROM locations;
 ```
+
+### rnd_geohash
+
+`rnd_geohash(bits)` - Returns a random geohash of variable precision.
+
+**Arguments:**
+
+- `bits` - An integer between `1` and `60` which determines the precision of the
+  generated geohash
+
+**Return value:**
+
+Returns a `geohash`.
+
+**Examples:**
+
+```questdb-sql title="Generate random geohashes of various precisions"
+SELECT
+    rnd_geohash(7) AS g7,
+    rnd_geohash(10) AS g10,
+    rnd_geohash(30) AS g30,
+    rnd_geohash(60) AS g60
+FROM long_sequence(3);
+```
+
+| g7      | g10 | g30    | g60          |
+| :------ | :-- | :----- | :----------- |
+| 1101100 | 4h  | hsmmq8 | rjtwedd0z72p |
+| 0010011 | vf  | f9jc1q | fzj09w97tj1h |
+| 0101011 | kx  | fkhked | v4cs8qsnjkeh |
 
 ## See also
 

--- a/documentation/query/functions/text.md
+++ b/documentation/query/functions/text.md
@@ -62,6 +62,33 @@ trades,instrument=EW,side=S price=10427,quantity=1945 1571270400300
 trades,instrument=MI,side=B price=99348,quantity=8450 1571270400400
 ```
 
+## left
+
+`left(string, count)` - extracts a substring of the given length from a string
+(starting from left).
+
+**Arguments:**
+
+- `string` is a string to extract from.
+- `count` is an integer specifying the count of characters to be extracted into
+  a substring.
+
+**Return value:**
+
+Returns a string with the extracted characters.
+
+**Examples:**
+
+```questdb-sql title="Example"
+SELECT name, left('Thompson', 3) l FROM names LIMIT 3
+```
+
+| name   | l   |
+| ------ | --- |
+| AARON  | AAR |
+| AMELIE | AME |
+| TOM    | TOM |
+
 ## length
 
 `length(value)` - reads length of the given value.
@@ -120,89 +147,6 @@ SELECT name a, length_bytes(name) b FROM names limit 4
 | ДЖЕК   | 8   |
 | null   | -1  |
 
-## left
-
-`left(string, count)` - extracts a substring of the given length from a string
-(starting from left).
-
-**Arguments:**
-
-- `string` is a string to extract from.
-- `count` is an integer specifying the count of characters to be extracted into
-  a substring.
-
-**Return value:**
-
-Returns a string with the extracted characters.
-
-**Examples:**
-
-```questdb-sql title="Example"
-SELECT name, left('Thompson', 3) l FROM names LIMIT 3
-```
-
-| name   | l   |
-| ------ | --- |
-| AARON  | AAR |
-| AMELIE | AME |
-| TOM    | TOM |
-
-## right
-
-`right(string, count)` - extracts a substring of the given length from a string
-(starting from right).
-
-**Arguments:**
-
-- `string` is a string to extract from.
-- `count` is an integer specifying the count of characters to be extracted into
-  a substring.
-
-**Return value:**
-
-Returns a string with the extracted characters.
-
-**Examples:**
-
-```questdb-sql title="Example"
-SELECT name, right('Thompson', 2) r FROM names LIMIT 3
-```
-
-| name   | l   |
-| ------ | --- |
-| AARON  | ON  |
-| AMELIE | IE  |
-| TOM    | OM  |
-
-## replace
-
-`replace` replaces all occurrences of a substring within a string with another
-substring.
-
-**Arguments:**
-
-- `replace(string, from_string, to_string)`
-
-  - `string` is the original string where replacements will be made.
-  - `from_string` is the substring that will be searched for in the original
-    string.
-  - `to_string` is the substring that will replace occurrences of `from_string`.
-
-**Return value:**
-
-Returns a new string that is derived from the original string by replacing every
-occurrence of `from_string` with `to_string`.
-
-**Examples:**
-
-```sql
-SELECT replace('Hello World', 'World', 'QuestDB');
-```
-
-| replace       |
-| ------------- |
-| Hello QuestDB |
-
 ## lpad
 
 **Arguments:**
@@ -254,6 +198,92 @@ SELECT ltrim('   QuestDB   ') AS trimmed_string;
 | ------------------------------- |
 | QuestDB&nbsp;&nbsp;&nbsp;&nbsp; |
 
+## quote_ident
+
+**Arguments:**
+
+- `quote_ident(string)`
+  - `string` is the string that may need quoting to be used as a SQL identifier.
+
+**Return value:**
+
+Returns the value enclosed in quotes if needed to make it a valid SQL
+identifier, else the value unchanged.
+
+**Examples:**
+
+```sql
+SELECT quote_ident("a b");
+```
+
+| quote_ident |
+| ----------- |
+| "a b"       |
+
+```sql
+SELECT quote_ident("ab");
+```
+
+| quote_ident |
+| ----------- |
+| ab          |
+
+## replace
+
+`replace` replaces all occurrences of a substring within a string with another
+substring.
+
+**Arguments:**
+
+- `replace(string, from_string, to_string)`
+
+  - `string` is the original string where replacements will be made.
+  - `from_string` is the substring that will be searched for in the original
+    string.
+  - `to_string` is the substring that will replace occurrences of `from_string`.
+
+**Return value:**
+
+Returns a new string that is derived from the original string by replacing every
+occurrence of `from_string` with `to_string`.
+
+**Examples:**
+
+```sql
+SELECT replace('Hello World', 'World', 'QuestDB');
+```
+
+| replace       |
+| ------------- |
+| Hello QuestDB |
+
+## right
+
+`right(string, count)` - extracts a substring of the given length from a string
+(starting from right).
+
+**Arguments:**
+
+- `string` is a string to extract from.
+- `count` is an integer specifying the count of characters to be extracted into
+  a substring.
+
+**Return value:**
+
+Returns a string with the extracted characters.
+
+**Examples:**
+
+```questdb-sql title="Example"
+SELECT name, right('Thompson', 2) r FROM names LIMIT 3
+```
+
+| name   | l   |
+| ------ | --- |
+| AARON  | ON  |
+| AMELIE | IE  |
+| TOM    | OM  |
+
 ## rtrim
 
 `rtrim` extracts white space from the right of a string value.
@@ -276,29 +306,6 @@ SELECT rtrim('Hello QuestDB   ');
 | rtrim         |
 | ------------- |
 | Hello QuestDB |
-
-## trim
-
-**Arguments:**
-
-- `trim(string)`
-
-  - `string` is the input string from which you want to remove leading and
-    trailing whitespace.
-
-**Return value:**
-
-Returns a string with leading and trailing whitespace removed.
-
-**Example:**
-
-```questdb-sql title="Using trim function"
-SELECT trim('   QuestDB   ') AS trimmed_string;
-```
-
-| trim    |
-| ------- |
-| QuestDB |
 
 ## split_part
 
@@ -554,32 +561,25 @@ SELECT to_uppercase('questDB');
 | ------------ |
 | QUESTDB      |
 
-## quote_ident
+## trim
 
 **Arguments:**
 
-- `quote_ident(string)`
-  - `string` is the string that may need quoting to be used as a SQL identifier.
+- `trim(string)`
+
+  - `string` is the input string from which you want to remove leading and
+    trailing whitespace.
 
 **Return value:**
 
-Returns the value enclosed in quotes if needed to make it a valid SQL
-identifier, else the value unchanged.
+Returns a string with leading and trailing whitespace removed.
 
-**Examples:**
+**Example:**
 
-```sql
-SELECT quote_ident("a b");
+```questdb-sql title="Using trim function"
+SELECT trim('   QuestDB   ') AS trimmed_string;
 ```
 
-| quote_ident |
-| ----------- |
-| "a b"       |
-
-```sql
-SELECT quote_ident("ab");
-```
-
-| quote_ident |
-| ----------- |
-| ab          |
+| trim    |
+| ------- |
+| QuestDB |

--- a/documentation/query/functions/trigonometric.md
+++ b/documentation/query/functions/trigonometric.md
@@ -14,13 +14,14 @@ Positive and negative infinity values are expressed as `'Infinity'` or
 
 :::
 
-## sin
+## acos
 
-`sin(angleRadians)` returns the trigonometric sine of an angle.
+`acos(value)` returns the arccosine of a value.
 
 ### Arguments
 
-- `angleRadians` is a numeric value indicating the angle in radians.
+- `value` is a numeric value whose arccosine is to be returned. The returned
+  angle is between 0.0 and pi inclusively.
 
 ### Return value
 
@@ -28,102 +29,18 @@ Return value type is `double`.
 
 ### Description
 
-Special case: if the argument is `NaN` or an infinity, then the result is
-`Null`.
+Special cases: if the argument is `NaN` or its absolute value is greater than 1,
+then the result is `Null`.
 
 ### Examples
 
 ```questdb-sql
-SELECT pi()/2 angle, sin(pi()/2) sin;
+SELECT acos(0.0) acos;
 ```
 
-| angle          | sin |
-| -------------- | --- |
-| 1.570796326794 | 1   |
-
-## cos
-
-`cos(angleRadians)` returns the trigonometric cosine of an angle.
-
-### Arguments
-
-- `angleRadians` numeric value for the angle, in radians.
-
-### Return value
-
-Return value type is `double`.
-
-### Description
-
-Special case: if the argument is `NaN` or an infinity, then the result is
-`Null`.
-
-### Examples
-
-```questdb-sql
-SELECT pi()/2 angle, cos(pi()/2) cos;
-```
-
-| angle          | cos                   |
-| -------------- | --------------------- |
-| 1.570796326794 | 6.123233995736766e-17 |
-
-## tan
-
-`tan(angleRadians)` returns the trigonometric tangent of an angle.
-
-### Arguments
-
-- `angleRadians` numeric value for the angle, in radians.
-
-### Return value
-
-Return value type is `double`.
-
-### Description
-
-Special case: if the argument is `NaN` or an infinity, then the result is
-`Null`.
-
-### Examples
-
-```questdb-sql
-SELECT pi()/2 angle, tan(pi()/2) tan;
-```
-
-| angle          | tan               |
-| -------------- | ----------------- |
-| 1.570796326794 | 16331239353195370 |
-
-## cot
-
-`cot(angleRadians)` returns the trigonometric cotangent of an angle.
-
-### Arguments
-
-- `angleRadians` numeric value for the angle, in radians.
-
-### Return value
-
-Return value type is `double`.
-
-### Description
-
-Special case: if the argument is `NaN`, 0, or an infinity, then the result is
-`Null`.
-
-<!-- - If the argument is 0, then the result is positive infin.
-Currently returning null TBD-->
-
-### Examples
-
-```questdb-sql
-SELECT pi()/2 angle, cot(pi()/2) cot;
-```
-
-| angle          | cot                   |
-| -------------- | --------------------- |
-| 1.570796326794 | 6.123233995736766e-17 |
+| acos           |
+| -------------- |
+| 1.570796326794 |
 
 ## asin
 
@@ -150,34 +67,6 @@ SELECT asin(1.0) asin;
 ```
 
 | asin           |
-| -------------- |
-| 1.570796326794 |
-
-## acos
-
-`acos(value)` returns the arccosine of a value.
-
-### Arguments
-
-- `value` is a numeric value whose arccosine is to be returned. The returned
-  angle is between 0.0 and pi inclusively.
-
-### Return value
-
-Return value type is `double`.
-
-### Description
-
-Special cases: if the argument is `NaN` or its absolute value is greater than 1,
-then the result is `Null`.
-
-### Examples
-
-```questdb-sql
-SELECT acos(0.0) acos;
-```
-
-| acos           |
 | -------------- |
 | 1.570796326794 |
 
@@ -285,28 +174,62 @@ SELECT atan2(1.0, 1.0) atan2;
 | -------------- |
 | 0.785398163397 |
 
-## radians
+## cos
 
-`radians(angleDegrees)` converts an angle measured in degrees to the equivalent
-angle measured in radians.
+`cos(angleRadians)` returns the trigonometric cosine of an angle.
 
 ### Arguments
 
-- `angleDegrees` numeric value for the angle in degrees.
+- `angleRadians` numeric value for the angle, in radians.
 
 ### Return value
 
 Return value type is `double`.
 
+### Description
+
+Special case: if the argument is `NaN` or an infinity, then the result is
+`Null`.
+
 ### Examples
 
 ```questdb-sql
-SELECT radians(180);
+SELECT pi()/2 angle, cos(pi()/2) cos;
 ```
 
-| radians        |
-| -------------- |
-| 3.141592653589 |
+| angle          | cos                   |
+| -------------- | --------------------- |
+| 1.570796326794 | 6.123233995736766e-17 |
+
+## cot
+
+`cot(angleRadians)` returns the trigonometric cotangent of an angle.
+
+### Arguments
+
+- `angleRadians` numeric value for the angle, in radians.
+
+### Return value
+
+Return value type is `double`.
+
+### Description
+
+Special case: if the argument is `NaN`, 0, or an infinity, then the result is
+`Null`.
+
+<!-- - If the argument is 0, then the result is positive infin.
+Currently returning null TBD-->
+
+### Examples
+
+```questdb-sql
+SELECT pi()/2 angle, cot(pi()/2) cot;
+```
+
+| angle          | cot                   |
+| -------------- | --------------------- |
+| 1.570796326794 | 6.123233995736766e-17 |
 
 ## degrees
 
@@ -352,3 +275,80 @@ SELECT pi();
 | pi             |
 | -------------- |
 | 3.141592653589 |
+
+## radians
+
+`radians(angleDegrees)` converts an angle measured in degrees to the equivalent
+angle measured in radians.
+
+### Arguments
+
+- `angleDegrees` numeric value for the angle in degrees.
+
+### Return value
+
+Return value type is `double`.
+
+### Examples
+
+```questdb-sql
+SELECT radians(180);
+```
+
+| radians        |
+| -------------- |
+| 3.141592653589 |
+
+## sin
+
+`sin(angleRadians)` returns the trigonometric sine of an angle.
+
+### Arguments
+
+- `angleRadians` is a numeric value indicating the angle in radians.
+
+### Return value
+
+Return value type is `double`.
+
+### Description
+
+Special case: if the argument is `NaN` or an infinity, then the result is
+`Null`.
+
+### Examples
+
+```questdb-sql
+SELECT pi()/2 angle, sin(pi()/2) sin;
+```
+
+| angle          | sin |
+| -------------- | --- |
+| 1.570796326794 | 1   |
+
+## tan
+
+`tan(angleRadians)` returns the trigonometric tangent of an angle.
+
+### Arguments
+
+- `angleRadians` numeric value for the angle, in radians.
+
+### Return value
+
+Return value type is `double`.
+
+### Description
+
+Special case: if the argument is `NaN` or an infinity, then the result is
+`Null`.
+
+### Examples
+
+```questdb-sql
+SELECT pi()/2 angle, tan(pi()/2) tan;
+```
+
+| angle          | tan               |
+| -------------- | ----------------- |
+| 1.570796326794 | 16331239353195370 |

--- a/documentation/query/functions/window-functions/reference.md
+++ b/documentation/query/functions/window-functions/reference.md
@@ -185,6 +185,60 @@ WHERE timestamp IN '[$today]';
 
 ---
 
+### corr() {#corr}
+
+Calculates the Pearson correlation coefficient between two numeric columns over the window frame. The result ranges from -1 (perfect negative correlation) to +1 (perfect positive correlation), with 0 indicating no linear relationship.
+
+**Syntax:**
+```questdb-sql
+corr(y, x) OVER (window_definition)
+```
+
+**Arguments:**
+- `y`: Numeric column - the dependent variable
+- `x`: Numeric column - the independent variable
+
+Rows where either `x` or `y` is `NULL` are excluded from the computation.
+
+**Return value:**
+- `double` - The Pearson correlation coefficient. Returns `NULL` when there are fewer than 2 valid pairs, or when either variable has zero variance (all values identical).
+
+**Description:**
+
+Unlike covariance, correlation is unitless and normalized, making it easier to interpret and compare across different scales. Use correlation as a window function for:
+
+- **Rolling correlation**: Track how the relationship between two metrics changes over time
+- **Regime detection**: Identify periods where correlations break down (e.g., market stress)
+- **Sensor diagnostics**: Detect when two readings that should be correlated start diverging
+- **Fleet analytics**: Compare per-device correlations against fleet-wide correlation
+
+**Example:**
+```questdb-sql title="Rolling correlation between two metrics"
+SELECT
+    ts,
+    robot_id,
+    corr(motor_temp, joint_velocity) OVER (
+        PARTITION BY robot_id
+        ORDER BY ts
+        ROWS BETWEEN 99 PRECEDING AND CURRENT ROW
+    ) AS rolling_corr
+FROM telemetry;
+```
+
+```questdb-sql title="Per-device correlation vs fleet"
+SELECT robot_id, device_corr,
+    avg(device_corr) OVER () AS fleet_avg_corr
+FROM (
+    SELECT robot_id,
+        corr(motor_temp, joint_velocity) AS device_corr
+    FROM telemetry
+    WHERE ts > dateadd('d', -1, now())
+    GROUP BY robot_id
+);
+```
+
+---
+
 ### count()
 
 Counts rows or non-null values over the window frame.
@@ -227,41 +281,91 @@ WHERE timestamp IN '[$today]';
 
 ---
 
-### sum()
+### covar_pop() / covar_samp() {#covariance}
 
-Calculates the sum of values over the window frame. Commonly used for running totals.
+Calculates the covariance between two numeric columns over the window frame. Covariance measures how two variables change together. `covar_pop()` computes population covariance (divides by N), `covar_samp()` computes sample covariance (divides by N-1).
 
 **Syntax:**
 ```questdb-sql
-sum(value) OVER (window_definition)
+covar_pop(y, x) OVER (window_definition)
+covar_samp(y, x) OVER (window_definition)
 ```
 
 **Arguments:**
-- `value`: Numeric column (`short`, `int`, `long`, `float`, `double`)
+- `y`: Numeric column - the dependent variable
+- `x`: Numeric column - the independent variable
+
+Rows where either `x` or `y` is `NULL` are excluded from the computation.
 
 **Return value:**
-- `double` - The sum of `value` for rows in the window frame
+- `double` - The covariance of `y` and `x` for rows in the window frame. Returns `NULL` when there are fewer than 1 (pop) or 2 (samp) valid pairs.
 
 **Description:**
 
-Use `sum()` as a window function when you need to track accumulation or totals over a sequence. Common use cases include:
+Covariance indicates the direction of the linear relationship between two variables. A positive covariance means they tend to increase together; negative means one increases as the other decreases. Use covariance as a window function for:
 
-- **Running totals**: Track cumulative values like total volume traded throughout the day
-- **Rolling sums**: Calculate sums over sliding windows (e.g., volume in the last 5 minutes)
-- **Budget tracking**: Show how spending accumulates against a budget over time
-- **Position tracking**: Calculate net position by summing buys and sells
+- **Correlation analysis**: Measure how sensor readings co-vary over rolling windows
+- **Portfolio analysis**: Track co-movement between asset prices
+- **Predictive modeling**: Identify which features move together with the target variable
 
 **Example:**
-```questdb-sql title="Cumulative amount" demo
+```questdb-sql title="Rolling covariance between temperature and velocity"
+SELECT
+    ts,
+    robot_id,
+    covar_pop(motor_temp, joint_velocity) OVER (
+        PARTITION BY robot_id
+        ORDER BY ts
+        ROWS BETWEEN 99 PRECEDING AND CURRENT ROW
+    ) AS temp_vel_covariance
+FROM telemetry;
+```
+
+---
+
+### first_value()
+
+Returns the first value in the window frame. Supports `IGNORE NULLS` clause.
+
+**Syntax:**
+```questdb-sql
+first_value(value) [(IGNORE|RESPECT) NULLS]
+OVER ([PARTITION BY partition_expression]
+      [ORDER BY sort_expression]
+      [frame_clause])
+```
+
+**Arguments:**
+- `value`: Column or expression to get value from
+- `IGNORE NULLS` (optional): Skip null values
+- `RESPECT NULLS` (default): Include null values
+
+**Return value:**
+- Same type as input - The first value in the window frame (or first non-null with `IGNORE NULLS`)
+
+**Description:**
+
+Use `first_value()` when you need to reference the starting point of a sequence. Common use cases include:
+
+- **Opening price**: Get the first price of each trading session to calculate daily returns
+- **Baseline comparison**: Compare each row to the first value in its partition
+- **Session start**: Reference the initial state at the beginning of each user session
+- **Gap filling**: Use `IGNORE NULLS` to carry forward the last known value when data is sparse
+
+**Example:**
+```questdb-sql title="First price in partition" demo
 SELECT
     symbol,
-    amount,
+    price,
     timestamp,
-    sum(amount) OVER (
+    first_value(price) OVER (
         PARTITION BY symbol
         ORDER BY timestamp
-        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-    ) AS cumulative_amount
+    ) AS first_price,
+    first_value(price) IGNORE NULLS OVER (
+        PARTITION BY symbol
+        ORDER BY timestamp
+    ) AS first_non_null_price
 FROM trades
 WHERE timestamp IN '[$today]';
 ```
@@ -324,44 +428,61 @@ WHERE timestamp IN '[$today]';
 
 ---
 
-### min()
+### last_value()
 
-Returns the minimum value within the window frame.
+Returns the last value in the window frame. Supports `IGNORE NULLS` clause.
 
 **Syntax:**
 ```questdb-sql
-min(value) OVER (window_definition)
+last_value(value) [(IGNORE|RESPECT) NULLS]
+OVER ([PARTITION BY partition_expression]
+      [ORDER BY sort_expression]
+      [frame_clause])
 ```
 
 **Arguments:**
-- `value`: Numeric column (`short`, `int`, `long`, `float`, `double`)
+- `value`: Column or expression to get value from
+- `IGNORE NULLS` (optional): Skip null values
+- `RESPECT NULLS` (default): Include null values
 
 **Return value:**
-- Same type as input - The minimum value (excluding null) in the window frame
+- Same type as input - The last value in the window frame (or last non-null with `IGNORE NULLS`)
 
 **Description:**
 
-Use `min()` as a window function when you need to track lowest values over a range. Common use cases include:
+Use `last_value()` when you need to reference the most recent or ending value in a sequence. Common use cases include:
 
-- **Support levels**: Track the lowest price within a rolling window for technical analysis
-- **Drawdown calculation**: Find the minimum value since a peak to measure decline
-- **Quality thresholds**: Identify the worst reading within each time period
-- **Intraday lows**: Track the lowest price per symbol throughout the trading day
+- **Closing price**: Get the last price in each time bucket for OHLC calculations
+- **Current state**: Access the most recent value in a rolling window
+- **Forward filling**: Use `IGNORE NULLS` to get the most recent non-null value for sparse data
+- **End-of-period values**: Capture the final state at partition boundaries
+
+**Frame behavior:**
+- Without `ORDER BY` or frame clause: default is `ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING`
+- With `ORDER BY` but no frame clause: default is `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`
 
 **Example:**
-```questdb-sql title="Rolling minimum price" demo
+```questdb-sql title="Last value with IGNORE NULLS" demo
 SELECT
-    symbol,
-    price,
     timestamp,
-    min(price) OVER (
+    price,
+    last_value(price) OVER (
         PARTITION BY symbol
         ORDER BY timestamp
-        ROWS BETWEEN 3 PRECEDING AND CURRENT ROW
-    ) AS lowest_price
+        ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+    ) AS last_price,
+    last_value(price) IGNORE NULLS OVER (
+        PARTITION BY symbol
+        ORDER BY timestamp
+    ) AS last_non_null_price
 FROM trades
 WHERE timestamp IN '[$today]';
 ```
+
+This example:
+- Gets the last price within a 3-row window for each symbol (`last_price`)
+- Gets the last non-null price for each symbol (`last_non_null_price`)
+- Demonstrates both `RESPECT NULLS` (default) and `IGNORE NULLS` behavior
 
 ---
 
@@ -400,6 +521,47 @@ SELECT
         ORDER BY timestamp
         ROWS BETWEEN 3 PRECEDING AND CURRENT ROW
     ) AS highest_price
+FROM trades
+WHERE timestamp IN '[$today]';
+```
+
+---
+
+### min()
+
+Returns the minimum value within the window frame.
+
+**Syntax:**
+```questdb-sql
+min(value) OVER (window_definition)
+```
+
+**Arguments:**
+- `value`: Numeric column (`short`, `int`, `long`, `float`, `double`)
+
+**Return value:**
+- Same type as input - The minimum value (excluding null) in the window frame
+
+**Description:**
+
+Use `min()` as a window function when you need to track lowest values over a range. Common use cases include:
+
+- **Support levels**: Track the lowest price within a rolling window for technical analysis
+- **Drawdown calculation**: Find the minimum value since a peak to measure decline
+- **Quality thresholds**: Identify the worst reading within each time period
+- **Intraday lows**: Track the lowest price per symbol throughout the trading day
+
+**Example:**
+```questdb-sql title="Rolling minimum price" demo
+SELECT
+    symbol,
+    price,
+    timestamp,
+    min(price) OVER (
+        PARTITION BY symbol
+        ORDER BY timestamp
+        ROWS BETWEEN 3 PRECEDING AND CURRENT ROW
+    ) AS lowest_price
 FROM trades
 WHERE timestamp IN '[$today]';
 ```
@@ -467,6 +629,47 @@ ORDER BY z_score DESC;
 
 ---
 
+### sum()
+
+Calculates the sum of values over the window frame. Commonly used for running totals.
+
+**Syntax:**
+```questdb-sql
+sum(value) OVER (window_definition)
+```
+
+**Arguments:**
+- `value`: Numeric column (`short`, `int`, `long`, `float`, `double`)
+
+**Return value:**
+- `double` - The sum of `value` for rows in the window frame
+
+**Description:**
+
+Use `sum()` as a window function when you need to track accumulation or totals over a sequence. Common use cases include:
+
+- **Running totals**: Track cumulative values like total volume traded throughout the day
+- **Rolling sums**: Calculate sums over sliding windows (e.g., volume in the last 5 minutes)
+- **Budget tracking**: Show how spending accumulates against a budget over time
+- **Position tracking**: Calculate net position by summing buys and sells
+
+**Example:**
+```questdb-sql title="Cumulative amount" demo
+SELECT
+    symbol,
+    amount,
+    timestamp,
+    sum(amount) OVER (
+        PARTITION BY symbol
+        ORDER BY timestamp
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS cumulative_amount
+FROM trades
+WHERE timestamp IN '[$today]';
+```
+
+---
+
 ### var_pop() / var_samp() / variance() {#variance}
 
 Calculates the variance of values over the window frame. Variance is the square of standard deviation. `var_pop()` computes population variance (divides by N), `var_samp()` computes sample variance (divides by N-1). `variance()` is an alias for `var_samp()`.
@@ -509,296 +712,9 @@ WHERE timestamp IN '[$today]';
 
 ---
 
-### covar_pop() / covar_samp() {#covariance}
-
-Calculates the covariance between two numeric columns over the window frame. Covariance measures how two variables change together. `covar_pop()` computes population covariance (divides by N), `covar_samp()` computes sample covariance (divides by N-1).
-
-**Syntax:**
-```questdb-sql
-covar_pop(y, x) OVER (window_definition)
-covar_samp(y, x) OVER (window_definition)
-```
-
-**Arguments:**
-- `y`: Numeric column — the dependent variable
-- `x`: Numeric column — the independent variable
-
-Rows where either `x` or `y` is `NULL` are excluded from the computation.
-
-**Return value:**
-- `double` - The covariance of `y` and `x` for rows in the window frame. Returns `NULL` when there are fewer than 1 (pop) or 2 (samp) valid pairs.
-
-**Description:**
-
-Covariance indicates the direction of the linear relationship between two variables. A positive covariance means they tend to increase together; negative means one increases as the other decreases. Use covariance as a window function for:
-
-- **Correlation analysis**: Measure how sensor readings co-vary over rolling windows
-- **Portfolio analysis**: Track co-movement between asset prices
-- **Predictive modeling**: Identify which features move together with the target variable
-
-**Example:**
-```questdb-sql title="Rolling covariance between temperature and velocity"
-SELECT
-    ts,
-    robot_id,
-    covar_pop(motor_temp, joint_velocity) OVER (
-        PARTITION BY robot_id
-        ORDER BY ts
-        ROWS BETWEEN 99 PRECEDING AND CURRENT ROW
-    ) AS temp_vel_covariance
-FROM telemetry;
-```
-
----
-
-### corr() {#corr}
-
-Calculates the Pearson correlation coefficient between two numeric columns over the window frame. The result ranges from -1 (perfect negative correlation) to +1 (perfect positive correlation), with 0 indicating no linear relationship.
-
-**Syntax:**
-```questdb-sql
-corr(y, x) OVER (window_definition)
-```
-
-**Arguments:**
-- `y`: Numeric column — the dependent variable
-- `x`: Numeric column — the independent variable
-
-Rows where either `x` or `y` is `NULL` are excluded from the computation.
-
-**Return value:**
-- `double` - The Pearson correlation coefficient. Returns `NULL` when there are fewer than 2 valid pairs, or when either variable has zero variance (all values identical).
-
-**Description:**
-
-Unlike covariance, correlation is unitless and normalized, making it easier to interpret and compare across different scales. Use correlation as a window function for:
-
-- **Rolling correlation**: Track how the relationship between two metrics changes over time
-- **Regime detection**: Identify periods where correlations break down (e.g., market stress)
-- **Sensor diagnostics**: Detect when two readings that should be correlated start diverging
-- **Fleet analytics**: Compare per-device correlations against fleet-wide correlation
-
-**Example:**
-```questdb-sql title="Rolling correlation between two metrics"
-SELECT
-    ts,
-    robot_id,
-    corr(motor_temp, joint_velocity) OVER (
-        PARTITION BY robot_id
-        ORDER BY ts
-        ROWS BETWEEN 99 PRECEDING AND CURRENT ROW
-    ) AS rolling_corr
-FROM telemetry;
-```
-
-```questdb-sql title="Per-device correlation vs fleet"
-SELECT robot_id, device_corr,
-    avg(device_corr) OVER () AS fleet_avg_corr
-FROM (
-    SELECT robot_id,
-        corr(motor_temp, joint_velocity) AS device_corr
-    FROM telemetry
-    WHERE ts > dateadd('d', -1, now())
-    GROUP BY robot_id
-);
-```
-
----
-
-### first_value()
-
-Returns the first value in the window frame. Supports `IGNORE NULLS` clause.
-
-**Syntax:**
-```questdb-sql
-first_value(value) [(IGNORE|RESPECT) NULLS]
-OVER ([PARTITION BY partition_expression]
-      [ORDER BY sort_expression]
-      [frame_clause])
-```
-
-**Arguments:**
-- `value`: Column or expression to get value from
-- `IGNORE NULLS` (optional): Skip null values
-- `RESPECT NULLS` (default): Include null values
-
-**Return value:**
-- Same type as input - The first value in the window frame (or first non-null with `IGNORE NULLS`)
-
-**Description:**
-
-Use `first_value()` when you need to reference the starting point of a sequence. Common use cases include:
-
-- **Opening price**: Get the first price of each trading session to calculate daily returns
-- **Baseline comparison**: Compare each row to the first value in its partition
-- **Session start**: Reference the initial state at the beginning of each user session
-- **Gap filling**: Use `IGNORE NULLS` to carry forward the last known value when data is sparse
-
-**Example:**
-```questdb-sql title="First price in partition" demo
-SELECT
-    symbol,
-    price,
-    timestamp,
-    first_value(price) OVER (
-        PARTITION BY symbol
-        ORDER BY timestamp
-    ) AS first_price,
-    first_value(price) IGNORE NULLS OVER (
-        PARTITION BY symbol
-        ORDER BY timestamp
-    ) AS first_non_null_price
-FROM trades
-WHERE timestamp IN '[$today]';
-```
-
----
-
-### last_value()
-
-Returns the last value in the window frame. Supports `IGNORE NULLS` clause.
-
-**Syntax:**
-```questdb-sql
-last_value(value) [(IGNORE|RESPECT) NULLS]
-OVER ([PARTITION BY partition_expression]
-      [ORDER BY sort_expression]
-      [frame_clause])
-```
-
-**Arguments:**
-- `value`: Column or expression to get value from
-- `IGNORE NULLS` (optional): Skip null values
-- `RESPECT NULLS` (default): Include null values
-
-**Return value:**
-- Same type as input - The last value in the window frame (or last non-null with `IGNORE NULLS`)
-
-**Description:**
-
-Use `last_value()` when you need to reference the most recent or ending value in a sequence. Common use cases include:
-
-- **Closing price**: Get the last price in each time bucket for OHLC calculations
-- **Current state**: Access the most recent value in a rolling window
-- **Forward filling**: Use `IGNORE NULLS` to get the most recent non-null value for sparse data
-- **End-of-period values**: Capture the final state at partition boundaries
-
-**Frame behavior:**
-- Without `ORDER BY` or frame clause: default is `ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING`
-- With `ORDER BY` but no frame clause: default is `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`
-
-**Example:**
-```questdb-sql title="Last value with IGNORE NULLS" demo
-SELECT
-    timestamp,
-    price,
-    last_value(price) OVER (
-        PARTITION BY symbol
-        ORDER BY timestamp
-        ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
-    ) AS last_price,
-    last_value(price) IGNORE NULLS OVER (
-        PARTITION BY symbol
-        ORDER BY timestamp
-    ) AS last_non_null_price
-FROM trades
-WHERE timestamp IN '[$today]';
-```
-
-This example:
-- Gets the last price within a 3-row window for each symbol (`last_price`)
-- Gets the last non-null price for each symbol (`last_non_null_price`)
-- Demonstrates both `RESPECT NULLS` (default) and `IGNORE NULLS` behavior
-
----
-
 ## Ranking functions
 
 These functions assign ranks or row numbers. They ignore the frame clause and operate on the entire partition.
-
-### row_number()
-
-Assigns a unique sequential number to each row within its partition, starting at 1.
-
-**Syntax:**
-```questdb-sql
-row_number() OVER (window_definition)
-```
-
-**Arguments:**
-- None required
-
-**Return value:**
-- Sequential row number (`long` type)
-
-**Description:**
-
-`row_number()` assigns unique numbers even when rows have equal values in the `ORDER BY` column. The assignment among equal values is non-deterministic.
-
-Use `row_number()` when you need unique sequential identifiers within groups. Common use cases include:
-
-- **Pagination**: Assign row numbers to implement efficient pagination over query results
-- **Deduplication**: Select only the first row from each group (where `row_number() = 1`)
-- **Top-N queries**: Get the top N records per category by filtering on row number
-- **Sequence generation**: Create sequential IDs within each partition for ordering or reference
-
-**Example:**
-```questdb-sql title="Number trades sequentially" demo
-SELECT
-    symbol,
-    price,
-    timestamp,
-    row_number() OVER (
-        PARTITION BY symbol
-        ORDER BY timestamp
-    ) AS trade_number
-FROM trades
-WHERE timestamp IN '[$today]';
-```
-
----
-
-### rank()
-
-Assigns ranks within a partition. Rows with equal values get the same rank, with gaps in the sequence.
-
-**Syntax:**
-```questdb-sql
-rank() OVER (window_definition)
-```
-
-**Arguments:**
-- None required
-
-**Return value:**
-- Rank number (`long` type)
-
-**Description:**
-
-With `rank()`, if two rows tie for rank 2, the next row gets rank 4 (not 3). The rank equals the `row_number` of the first row in its peer group.
-
-Use `rank()` when ties should share a rank and you want gaps to reflect the true position. Common use cases include:
-
-- **Competition ranking**: Assign standings where ties share a position (1st, 2nd, 2nd, 4th)
-- **Leaderboards**: Rank scores where tied values get the same rank
-- **Percentile buckets**: Group values by rank to create percentile bands
-- **Top performers**: Identify all items tied for top positions
-
-**Example:**
-```questdb-sql title="Rank by price" demo
-SELECT
-    symbol,
-    price,
-    timestamp,
-    rank() OVER (
-        PARTITION BY symbol
-        ORDER BY price DESC
-    ) AS price_rank
-FROM trades
-WHERE timestamp IN '[$today]';
-```
-
----
 
 ### dense_rank()
 
@@ -913,6 +829,90 @@ WHERE timestamp IN '[$today]'
 | BTC-USDT | 99 | 5 | 1.0 |
 
 In this example, `percent_rank` shows where each price falls relative to others: 0.0 means highest price, 1.0 means lowest, and 0.5 means middle of the distribution. Tied values (both 101) receive the same percent rank.
+
+---
+
+### rank()
+
+Assigns ranks within a partition. Rows with equal values get the same rank, with gaps in the sequence.
+
+**Syntax:**
+```questdb-sql
+rank() OVER (window_definition)
+```
+
+**Arguments:**
+- None required
+
+**Return value:**
+- Rank number (`long` type)
+
+**Description:**
+
+With `rank()`, if two rows tie for rank 2, the next row gets rank 4 (not 3). The rank equals the `row_number` of the first row in its peer group.
+
+Use `rank()` when ties should share a rank and you want gaps to reflect the true position. Common use cases include:
+
+- **Competition ranking**: Assign standings where ties share a position (1st, 2nd, 2nd, 4th)
+- **Leaderboards**: Rank scores where tied values get the same rank
+- **Percentile buckets**: Group values by rank to create percentile bands
+- **Top performers**: Identify all items tied for top positions
+
+**Example:**
+```questdb-sql title="Rank by price" demo
+SELECT
+    symbol,
+    price,
+    timestamp,
+    rank() OVER (
+        PARTITION BY symbol
+        ORDER BY price DESC
+    ) AS price_rank
+FROM trades
+WHERE timestamp IN '[$today]';
+```
+
+---
+
+### row_number()
+
+Assigns a unique sequential number to each row within its partition, starting at 1.
+
+**Syntax:**
+```questdb-sql
+row_number() OVER (window_definition)
+```
+
+**Arguments:**
+- None required
+
+**Return value:**
+- Sequential row number (`long` type)
+
+**Description:**
+
+`row_number()` assigns unique numbers even when rows have equal values in the `ORDER BY` column. The assignment among equal values is non-deterministic.
+
+Use `row_number()` when you need unique sequential identifiers within groups. Common use cases include:
+
+- **Pagination**: Assign row numbers to implement efficient pagination over query results
+- **Deduplication**: Select only the first row from each group (where `row_number() = 1`)
+- **Top-N queries**: Get the top N records per category by filtering on row number
+- **Sequence generation**: Create sequential IDs within each partition for ordering or reference
+
+**Example:**
+```questdb-sql title="Number trades sequentially" demo
+SELECT
+    symbol,
+    price,
+    timestamp,
+    row_number() OVER (
+        PARTITION BY symbol
+        ORDER BY timestamp
+    ) AS trade_number
+FROM trades
+WHERE timestamp IN '[$today]';
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Sort function reference pages alphabetically: array, aggregation, date-time, finance, meta, random value generator, row generator, spatial, text, trigonometric, and window functions
- Sort category/index tables within each page to match body order
- Add missing rnd_timestamp_ns documentation (random value generator)
- Add missing timestamp_sequence_ns documentation (row generator)
- Fix incorrect timestamp_sequence return type claim (always returns TIMESTAMP, not TIMESTAMP_NS)
- Fix array_elem_* function ordering (avg, max, min, sum)