### PR TITLE
ci(gitleaks): pin action to SHA and skip when license secret is missing

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,11 +9,15 @@ on:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    env:
+      # Hoisted to job-level env because the `secrets` context is not
+      # available in step-level `if` expressions; `env` is.
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        if: ${{ env.GITLEAKS_LICENSE != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
Pin gitleaks/gitleaks-action to a full commit SHA (v2.3.9) instead of the mutable v2 tag, so a compromise of the upstream repo or tag can't silently change what runs in CI.

Skip the step when GITLEAKS_LICENSE is empty. Pull requests from forks don't receive org secrets, which was causing the check to fail on external contributor PRs (e.g. #390).