### PR TITLE
Add npx install option for QuestDB agent skill

### DIFF
--- a/documentation/getting-started/ai-coding-agents.mdx
+++ b/documentation/getting-started/ai-coding-agents.mdx
@@ -5,6 +5,10 @@ description:
   Use AI coding agents like Claude Code or OpenAI Codex to build applications, write queries, and work with QuestDB using natural language.
 ---
 
+import Tabs from "@theme/Tabs";
+
+import TabItem from "@theme/TabItem";
+
 AI coding agents like <a href="https://claude.ai/code" target="_blank">Claude Code</a> and <a href="https://openai.com/index/openai-codex/" target="_blank">OpenAI Codex</a> can help you build applications that use QuestDB.
 
 These agents work with QuestDB out of the box by reading the online documentation. For deeper integration, agent skills embed rich context directly into the agent so it can work faster and more accurately. The [QuestDB agent skill](#questdb-agent-skill) covers SQL, ingestion, and Grafana dashboards, while the [TSBS Benchmark skill](#tsbs-benchmark-skill) automates end-to-end performance benchmarking.
@@ -50,6 +54,23 @@ The <a href="https://github.com/questdb/questdb-agent-skill" target="_blank">Que
 
 ### Installation
 
+<Tabs defaultValue="npx" values={[
+  { label: "npx (recommended)", value: "npx" },
+  { label: "Manual copy", value: "manual" },
+]}>
+
+<TabItem value="npx">
+
+```shell
+npx skills add questdb/questdb-agent-skill
+```
+
+This installs the skill globally for Claude Code. To install it for a specific project only, run the command from the project directory with the `--local` flag.
+
+</TabItem>
+
+<TabItem value="manual">
+
 Copy the `questdb/` folder from the <a href="https://github.com/questdb/questdb-agent-skill" target="_blank">repository</a> into your skills directory:
 
 **Claude Code:**
@@ -61,6 +82,10 @@ Copy the `questdb/` folder from the <a href="https://github.com/questdb/questdb-
 - `<project>/.codex/skills/questdb/` - available in a specific project
 
 The folder must contain `SKILL.md` and the `references/` directory.
+
+</TabItem>
+
+</Tabs>
 
 ### What's included
 


### PR DESCRIPTION
## Summary

- Add tabbed installation section for the QuestDB agent skill showing both `npx skills add` and manual copy methods