### PR TITLE
Fix PIVOT examples to use demo server data

### DIFF
--- a/documentation/query/sql/pivot.md
+++ b/documentation/query/sql/pivot.md
@@ -59,18 +59,18 @@ Specifies which column values become output columns:
 
 ```questdb-sql
 -- Static value list
-FOR symbol IN ('BTC-USD', 'ETH-USD')
+FOR symbol IN ('BTC-USDT', 'ETH-USDT', 'SOL-USDT')
 
 -- With aliases for column names
-FOR symbol IN ('BTC-USD' AS bitcoin, 'ETH-USD' AS ethereum)
+FOR symbol IN ('BTC-USDT' AS bitcoin, 'ETH-USDT' AS ethereum)
 
 -- Dynamic from subquery (executed at parse time)
-FOR symbol IN (SELECT DISTINCT symbol FROM trades)
+FOR symbol IN (SELECT DISTINCT symbol FROM trades WHERE timestamp IN '$today')
 
 -- Multiple FOR clauses create Cartesian product
-FOR symbol IN ('BTC-USD', 'ETH-USD')
+FOR symbol IN ('BTC-USDT', 'ETH-USDT')
     side IN ('buy', 'sell')
--- Produces: BTC-USD_buy, BTC-USD_sell, ETH-USD_buy, ETH-USD_sell
+-- Produces: BTC-USDT_buy, BTC-USDT_sell, ETH-USDT_buy, ETH-USDT_sell
 ```
 
 ### GROUP BY (optional, inside PIVOT)
@@ -80,7 +80,7 @@ Groups results by additional columns:
 ```questdb-sql
 PIVOT (
     sum(price * amount) / 2
-    FOR symbol IN ('BTC-USD', 'ETH-USD')
+    FOR symbol IN ('BTC-USDT', 'ETH-USDT')
     GROUP BY side    -- inside PIVOT parentheses
 )
 ```
@@ -97,7 +97,7 @@ Sort and limit the final result set:
 ```questdb-sql
 trades PIVOT (
     avg(price)
-    FOR symbol IN ('BTC-USD', 'ETH-USD')
+    FOR symbol IN ('BTC-USDT', 'ETH-USDT')
     GROUP BY side
 )
 ORDER BY side      -- outside PIVOT parentheses
@@ -110,83 +110,118 @@ LIMIT 10
 
 Transform rows to columns:
 
-```questdb-sql title="Row-based query"
+```questdb-sql demo title="Row-based query"
 SELECT symbol, avg(price)
 FROM trades
+WHERE timestamp IN '$today'
 GROUP BY symbol;
 ```
 
-| symbol  | avg      |
-| ------- | -------- |
-| BTC-USD | 39267.64 |
-| ETH-USD | 2615.42  |
+| symbol    | avg       |
+| --------- | --------- |
+| BTC-USDT  | 81690.81  |
+| ETH-USDT  | 2388.09   |
+| SOL-USDT  | 88.10     |
+| ADA-USDT  | 0.27      |
+| AVAX-USDT | 9.60      |
+| LTC-USDT  | 57.17     |
+| DOT-USDT  | 1.31      |
+| UNI-USDT  | 3.45      |
+| XLM-USDT  | 0.16      |
+| ETH-BTC   | 0.03      |
+| SOL-BTC   | 0.001     |
 
 Without `PIVOT`, converting rows to columns requires verbose `CASE` expressions:
 
-```questdb-sql title="Manual pivot with CASE"
+```questdb-sql demo title="Manual pivot with CASE"
 SELECT
-    avg(CASE WHEN symbol = 'BTC-USD' THEN price END) AS "BTC-USD",
-    avg(CASE WHEN symbol = 'ETH-USD' THEN price END) AS "ETH-USD"
-FROM trades;
+    avg(CASE WHEN symbol = 'BTC-USDT' THEN price END) AS "BTC-USDT",
+    avg(CASE WHEN symbol = 'ETH-USDT' THEN price END) AS "ETH-USDT",
+    avg(CASE WHEN symbol = 'SOL-USDT' THEN price END) AS "SOL-USDT",
+    avg(CASE WHEN symbol = 'ADA-USDT' THEN price END) AS "ADA-USDT",
+    avg(CASE WHEN symbol = 'AVAX-USDT' THEN price END) AS "AVAX-USDT"
+FROM trades
+WHERE timestamp IN '$today';
 ```
+
+| BTC-USDT | ETH-USDT | SOL-USDT | ADA-USDT | AVAX-USDT |
+| -------- | -------- | -------- | -------- | --------- |
+| 81690.82 | 2388.09  | 88.10    | 0.27     | 9.60      |
 
 `PIVOT` simplifies this pattern:
 
-```questdb-sql title="Pivoted to columns"
-trades PIVOT (
+```questdb-sql demo title="Pivoted to columns"
+SELECT * FROM trades
+WHERE timestamp IN '$today'
+PIVOT (
     avg(price)
-    FOR symbol IN ('BTC-USD', 'ETH-USD')
+    FOR symbol IN (
+        'BTC-USDT', 'ETH-USDT', 'SOL-USDT',
+        'ADA-USDT', 'AVAX-USDT'
+    )
 );
 ```
 
-| BTC-USD  | ETH-USD |
-| -------- | ------- |
-| 39267.64 | 2615.42 |
+| BTC-USDT | ETH-USDT | SOL-USDT | ADA-USDT | AVAX-USDT |
+| -------- | -------- | -------- | -------- | --------- |
+| 81683.77 | 2387.93  | 88.09    | 0.27     | 9.60      |
 
 ### Multiple aggregates
 
-```questdb-sql
-trades PIVOT (
+```questdb-sql demo title="Multiple aggregates per symbol"
+SELECT * FROM trades
+WHERE timestamp IN '$today'
+PIVOT (
     avg(price) AS avg_price,
     sum(price * amount) / 2 AS half_value
-    FOR symbol IN ('BTC-USD', 'ETH-USD')
+    FOR symbol IN ('BTC-USDT', 'ETH-USDT', 'SOL-USDT')
 );
 ```
 
-| BTC-USD_avg_price | BTC-USD_half_value | ETH-USD_avg_price | ETH-USD_half_value |
-| ----------------- | ------------------ | ----------------- | ------------------ |
-| 39267.64          | 24500.12           | 2615.42           | 588.25             |
+| BTC-USDT_avg_price | BTC-USDT_half_value | ETH-USDT_avg_price | ETH-USDT_half_value | SOL-USDT_avg_price | SOL-USDT_half_value |
+| ------------------ | ------------------- | ------------------ | ------------------- | ------------------ | ------------------- |
+| 81683.99           | 154998570.76        | 2387.94            | 80641109.01         | 88.09              | 24492519.72         |
 
 ### Multiple FOR clauses (Cartesian product)
 
-```questdb-sql
-trades PIVOT (
+```questdb-sql demo title="Pivot by symbol and side"
+SELECT * FROM trades
+WHERE timestamp IN '$today'
+PIVOT (
     avg(price)
-    FOR symbol IN ('BTC-USD', 'ETH-USD')
+    FOR symbol IN (
+        'BTC-USDT', 'ETH-USDT', 'SOL-USDT',
+        'ADA-USDT', 'AVAX-USDT'
+    )
         side IN ('buy', 'sell')
 );
 ```
 
-| BTC-USD_buy | BTC-USD_sell | ETH-USD_buy | ETH-USD_sell |
-| ----------- | ------------ | ----------- | ------------ |
-| 39300.00    | 39267.64     | 2620.00     | 2615.54      |
+| BTC-USDT_buy | BTC-USDT_sell | ETH-USDT_buy | ETH-USDT_sell | SOL-USDT_buy | SOL-USDT_sell | ADA-USDT_buy | ADA-USDT_sell | AVAX-USDT_buy | AVAX-USDT_sell |
+| ------------ | ------------- | ------------ | ------------- | ------------ | ------------- | ------------ | ------------- | ------------- | -------------- |
+| 81717.80     | 81645.93      | 2387.97      | 2387.92       | 88.13        | 88.05         | 0.2668       | 0.2671        | 9.6085        | 9.5972         |
 
 ### With GROUP BY
 
 Keep additional dimensions as rows:
 
-```questdb-sql
-trades PIVOT (
+```questdb-sql demo title="Pivot with GROUP BY"
+SELECT * FROM trades
+WHERE timestamp IN '$today'
+PIVOT (
     avg(price)
-    FOR symbol IN ('BTC-USD', 'ETH-USD')
+    FOR symbol IN (
+        'BTC-USDT', 'ETH-USDT', 'SOL-USDT',
+        'ADA-USDT', 'AVAX-USDT'
+    )
     GROUP BY side
 ) ORDER BY side;
 ```
 
-| side | BTC-USD  | ETH-USD |
-| ---- | -------- | ------- |
-| buy  | 39300.00 | 2620.00 |
-| sell | 39267.64 | 2615.54 |
+| side | BTC-USDT | ETH-USDT | SOL-USDT | ADA-USDT | AVAX-USDT |
+| ---- | -------- | -------- | -------- | -------- | --------- |
+| buy  | 81717.85 | 2387.97  | 88.13    | 0.2668   | 9.6085    |
+| sell | 81645.99 | 2387.92  | 88.05    | 0.2671   | 9.5972    |
 
 :::note
 When a GROUP BY key has no matching FOR values in the data, the entire row is
@@ -200,10 +235,16 @@ For example, if `side = 'hold'` exists but has no matching symbols, that row won
 
 Column names determined at query compile time:
 
-```questdb-sql
-trades PIVOT (
+```questdb-sql demo title="Dynamic pivot columns from subquery"
+SELECT * FROM trades
+WHERE timestamp IN '$today'
+PIVOT (
     avg(price)
-    FOR symbol IN (SELECT DISTINCT symbol FROM trades ORDER BY symbol)
+    FOR symbol IN (
+        SELECT DISTINCT symbol FROM trades
+        WHERE timestamp IN '$today'
+        ORDER BY symbol
+    )
     GROUP BY side
 );
 ```
@@ -227,15 +268,18 @@ use a constant list or store keys in a small dimension table for better performa
 
 ### With CTEs
 
-```questdb-sql
+```questdb-sql demo title="Pivot with CTE"
 WITH recent_trades AS (
     SELECT * FROM trades
-    WHERE timestamp > dateadd('d', -1, now())
+    WHERE timestamp IN '$today'
 )
 SELECT * FROM recent_trades
 PIVOT (
     avg(price)
-    FOR symbol IN (SELECT DISTINCT symbol FROM recent_trades)
+    FOR symbol IN (
+        SELECT DISTINCT symbol FROM recent_trades
+        ORDER BY symbol
+    )
     GROUP BY side
 );
 ```
@@ -246,41 +290,47 @@ Output columns are automatically named based on the combination of FOR values an
 
 With a **single aggregate**, columns are named using just the FOR value:
 
-```questdb-sql
-trades PIVOT (
+```questdb-sql demo title="Single aggregate column names"
+-- Columns: BTC-USDT, ETH-USDT
+SELECT * FROM trades
+WHERE timestamp IN '$today'
+PIVOT (
     avg(price)
-    FOR symbol IN ('BTC-USD', 'ETH-USD')
+    FOR symbol IN ('BTC-USDT', 'ETH-USDT')
 );
--- Columns: BTC-USD, ETH-USD
 ```
 
 With **multiple aggregates**, the full function expression is included:
 
-```questdb-sql
-trades PIVOT (
+```questdb-sql demo title="Multiple aggregate column names"
+-- Columns: BTC-USDT_avg(price), BTC-USDT_sum(price), ...
+SELECT * FROM trades
+WHERE timestamp IN '$today'
+PIVOT (
     avg(price), sum(price)
-    FOR symbol IN ('BTC-USD', 'ETH-USD')
+    FOR symbol IN ('BTC-USDT', 'ETH-USDT')
 );
--- Columns: BTC-USD_avg(price), BTC-USD_sum(price), ETH-USD_avg(price), ETH-USD_sum(price)
 ```
 
 Use **aliases** for cleaner column names:
 
-```questdb-sql
-trades PIVOT (
+```questdb-sql demo title="Aliased column names"
+-- Columns: BTC-USDT_avg_price, BTC-USDT_total_price, ...
+SELECT * FROM trades
+WHERE timestamp IN '$today'
+PIVOT (
     avg(price) AS avg_price, sum(price) AS total_price
-    FOR symbol IN ('BTC-USD', 'ETH-USD')
+    FOR symbol IN ('BTC-USDT', 'ETH-USDT')
 );
--- Columns: BTC-USD_avg_price, BTC-USD_total_price, ETH-USD_avg_price, ETH-USD_total_price
 ```
 
-| Scenario                | Example                                            | Column name                        |
-| ----------------------- | -------------------------------------------------- | ---------------------------------- |
-| Single aggregate        | `avg(price) FOR symbol IN ('BTC')`                 | `BTC`                              |
-| Multiple aggregates     | `avg(price), sum(price) FOR symbol IN ('BTC')`     | `BTC_avg(price)`, `BTC_sum(price)` |
-| Multiple FOR            | `avg(price) FOR symbol IN ('BTC') side IN ('buy')` | `BTC_buy`                          |
-| With alias on value     | `FOR symbol IN ('BTC-USD' AS btc)`                 | `btc`                              |
-| With alias on aggregate | `avg(price) AS avg_price FOR symbol IN ('BTC')`    | `BTC_avg_price`                    |
+| Scenario                | Example                                              | Column name                            |
+| ----------------------- | ---------------------------------------------------- | -------------------------------------- |
+| Single aggregate        | `avg(price) FOR symbol IN ('BTC-USDT')`              | `BTC-USDT`                             |
+| Multiple aggregates     | `avg(price), sum(price) FOR symbol IN ('BTC-USDT')`  | `BTC-USDT_avg(price)`, `BTC-USDT_sum(price)` |
+| Multiple FOR            | `avg(price) FOR symbol IN ('BTC-USDT') side IN ('buy')` | `BTC-USDT_buy`                      |
+| With alias on value     | `FOR symbol IN ('BTC-USDT' AS btc)`                  | `btc`                                  |
+| With alias on aggregate | `avg(price) AS avg_price FOR symbol IN ('BTC-USDT')` | `BTC-USDT_avg_price`                   |
 
 ## Limits
 
@@ -288,11 +338,11 @@ PIVOT has a configurable maximum column limit (default: 5000) to prevent excessi
 The total columns = `(FOR value combinations) × (number of aggregates)`.
 
 ```questdb-sql
--- This would fail if combinations × aggregates > 5000
+-- Fails if combinations × aggregates exceeds 5000
 trades PIVOT (
     avg(price)
     FOR symbol IN (SELECT DISTINCT symbol FROM trades)  -- many symbols
-        side IN ('buy', 'sell')                         -- × 2
+        side IN ('buy', 'sell')                         -- x 2
 );
 ```
 


### PR DESCRIPTION
## Summary

- Updated all PIVOT page examples to use correct demo `trades` table symbols (`BTC-USDT`, `ETH-USDT`, `SOL-USDT`, `ADA-USDT`, `AVAX-USDT`) instead of non-existent `BTC-USD`/`ETH-USD`
- Added `demo` tag and titles to all runnable query blocks so they link to demo.questdb.io
- Added result tables to examples with static symbol lists
- Replaced `dateadd()` with TICK syntax (`'$today'`)
- Added `WHERE timestamp IN '$today'` filter to dynamic subqueries to avoid NULL columns from retired symbols