### PR TITLE
fix invalid range for timestamp_ns

### DIFF
--- a/documentation/query/functions/date-time.md
+++ b/documentation/query/functions/date-time.md
@@ -15,7 +15,7 @@ QuestDB has three temporal types with different precision:
 | :--- | :-------- | :---------------- |
 | `DATE` | milliseconds | ±2.9 million years |
 | `TIMESTAMP` | microseconds | ±290,000 years |
-| `TIMESTAMP_NS` | nanoseconds | ±2,920 years |
+| `TIMESTAMP_NS` | nanoseconds | ±292 years |
 
 All three are stored as signed 64-bit integers representing offsets from the
 Unix epoch. `TIMESTAMP` is recommended for most use cases as it offers the


### PR DESCRIPTION
This PR fixes the TIMESTAMP_NS range, it was documented to be 2920 years while it actually is 292 years.
