### PR TITLE
Add cookbook link to SELECT page tip

### DIFF
--- a/documentation/query/sql/select.md
+++ b/documentation/query/sql/select.md
@@ -9,9 +9,10 @@ and evaluated from a table.
 
 :::tip
 
-Looking for SELECT best practices? Checkout our
-[**Maximize your SQL efficiency: SELECT best practices**](/blog/2024/03/11/sql-select-statement-best-practices/)
-blog.
+For realistic queries solving specific use cases, see the
+[**Cookbook**](/docs/cookbook/). For SELECT best practices, check out our
+[**SQL SELECT best practices**](/blog/2024/03/11/sql-select-statement-best-practices/)
+blog post.
 
 :::
 


### PR DESCRIPTION
## Summary

- Adds a link to the Cookbook in the existing tip box on the SELECT reference page
- Rewords the tip to lead with the cookbook for realistic use-case queries, followed by the best practices blog link