### PR TITLE
Replace GROUP BY examples with fx_trades demo queries

### DIFF
--- a/documentation/query/sql/group-by.md
+++ b/documentation/query/sql/group-by.md
@@ -28,51 +28,87 @@ explicitly will return the same results as if the clause was omitted.
 The below queries perform aggregations on a single key. Using `GROUP BY`
 explicitly or implicitly yields the same results:
 
-```questdb-sql title="Single key aggregation, explicit GROUP BY"
-SELECT symbol, avg(price)
-FROM trades
-GROUP BY symbol;
+```questdb-sql demo title="Single key aggregation, explicit GROUP BY"
+SELECT symbol, avg(price), count()
+FROM fx_trades
+WHERE timestamp IN '$today'
+GROUP BY symbol
+LIMIT 5;
 ```
 
-```questdb-sql title="Single key aggregation, implicit GROUP BY"
-SELECT symbol, avg(price)
-FROM trades;
+| symbol | avg    | count  |
+| ------ | ------ | ------ |
+| EURCAD | 1.5956 | 31597  |
+| EURUSD | 1.1701 | 315311 |
+| USDMXN | 17.243 | 31852  |
+| GBPJPY | 212.12 | 31442  |
+| AUDJPY | 113.10 | 32153  |
+
+```questdb-sql demo title="Single key aggregation, implicit GROUP BY"
+SELECT symbol, avg(price), count()
+FROM fx_trades
+WHERE timestamp IN '$today'
+LIMIT 5;
 ```
 
 The below queries perform aggregations on multiple keys. Using `GROUP BY`
 explicitly or implicitly yields the same results:
 
-```questdb-sql title="Multiple key aggregation, explicit GROUP BY"
+```questdb-sql demo title="Multiple key aggregation, explicit GROUP BY"
+SELECT symbol, side, avg(price), count()
+FROM fx_trades
+WHERE timestamp IN '$today'
+GROUP BY symbol, side
+LIMIT 5;
+```
+
+| symbol | side | avg    | count  |
+| ------ | ---- | ------ | ------ |
+| USDCAD | sell | 1.3601 | 79061  |
+| NZDUSD | buy  | 0.5944 | 31364  |
+| EURUSD | sell | 1.1697 | 157235 |
+| EURCHF | buy  | 0.9149 | 15206  |
+| EURUSD | buy  | 1.1705 | 158076 |
+
+```questdb-sql demo title="Multiple key aggregation, implicit GROUP BY"
+SELECT symbol, side, avg(price), count()
+FROM fx_trades
+WHERE timestamp IN '$today'
+LIMIT 5;
+```
+
+When used explicitly, every non-aggregated column in the `SELECT` clause must
+appear in `GROUP BY`, otherwise an error will be returned:
+
+```questdb-sql title="Error - side is missing in the GROUP BY clause"
 SELECT symbol, side, avg(price)
-FROM trades
-GROUP BY symbol, side;
+FROM fx_trades
+GROUP BY symbol;
 ```
 
-```questdb-sql title="Multiple key aggregation, implicit GROUP BY"
-SELECT symbol, side, avg(price)
-FROM trades;
+The reverse is allowed. Extra columns in `GROUP BY` that are not in `SELECT`
+will produce a valid result, but the same symbol may appear multiple times
+(once per value of the extra key). This can be misleading, which is a good
+reason to prefer implicit `GROUP BY` where QuestDB always groups by exactly
+the non-aggregated columns in `SELECT`:
+
+```questdb-sql demo title="Extra GROUP BY key not in SELECT"
+SELECT symbol, avg(price)
+FROM fx_trades
+WHERE timestamp IN '$today'
+GROUP BY symbol, side
+ORDER BY symbol
+LIMIT 6;
 ```
 
-When used explicitly, the list of keys in the `GROUP BY` clause must match the
-list of keys in the `SELECT` clause, otherwise an error will be returned:
-
-```questdb-sql title="Error - Column b is missing in the GROUP BY clause"
-SELECT a, b, avg(temp)
-FROM tab
-GROUP BY a;
-```
-
-```questdb-sql title="Error - Column b is missing in the SELECT clause"
-SELECT a, avg(temp)
-FROM tab
-GROUP BY a, b;
-```
-
-```questdb-sql title="Success - Columns match"
-SELECT a, b, avg(temp)
-FROM tab
-GROUP BY a, b;
-```
+| symbol | avg      |
+| ------ | -------- |
+| AUDCAD | 0.9846   |
+| AUDCAD | 0.9838   |
+| AUDJPY | 113.1422 |
+| AUDJPY | 113.0659 |
+| AUDNZD | 1.2127   |
+| AUDNZD | 1.2118   |
 
 ## See also
 


### PR DESCRIPTION
## Summary

- Replaces fictional table examples with runnable `fx_trades` queries using `demo` tag and TICK syntax
- Adds result tables to illustrate output
- Fixes incorrect error example: extra columns in GROUP BY that are not in SELECT is valid SQL, not an error. Only the reverse (SELECT columns missing from GROUP BY) is an error
- Adds example showing the subtle duplicate-row effect of extra GROUP BY keys