### PR TITLE
Add upgrade QuestDB page

### DIFF
--- a/documentation/getting-started/migrate-to-enterprise.md
+++ b/documentation/getting-started/migrate-to-enterprise.md
@@ -10,6 +10,11 @@ Upgrading from QuestDB Open Source to QuestDB Enterprise is straightforward:
 **download the Enterprise binaries, swap them in, and restart**. Your data
 stays in place and works immediately.
 
+:::info Looking to upgrade to a newer version?
+This page covers switching from Open Source to Enterprise. To upgrade QuestDB to
+a newer release, see [Upgrade QuestDB](/docs/operations/upgrade/).
+:::
+
 ## What you get with QuestDB Enterprise
 
 - **TLS encryption** for all network interfaces

--- a/documentation/getting-started/quick-start.mdx
+++ b/documentation/getting-started/quick-start.mdx
@@ -39,6 +39,10 @@ production hosting.
 > **QuestDB already running? [Jump ahead!](/docs/getting-started/quick-start/#bring-your-data)
 > Select a first-party client or ingest method.**
 
+:::tip Upgrading an existing instance?
+See the [Upgrade QuestDB](/docs/operations/upgrade/) guide.
+:::
+
 ## Install QuestDB
 
 Choose from the following options:

--- a/documentation/operations/upgrade.md
+++ b/documentation/operations/upgrade.md
@@ -1,0 +1,100 @@
+---
+title: Upgrade QuestDB
+sidebar_label: Upgrade QuestDB
+description:
+  How to upgrade QuestDB to a newer version using Docker or binaries, for both
+  open source and enterprise editions.
+---
+
+Upgrading QuestDB to a newer version requires replacing the server binary (or
+pulling a new Docker image) and restarting the process. Your existing data
+directory stays in place. This applies to both QuestDB Open Source and QuestDB
+Enterprise.
+
+:::info Looking for a fresh install?
+If this is your first time setting up QuestDB, see the
+[Quick start](/docs/getting-started/quick-start/) guide instead.
+:::
+
+## Before you upgrade
+
+1. **Read the [release notes](https://questdb.com/release-notes/).** QuestDB is
+   generally backwards compatible, but breaking changes do occur and are
+   documented in the release notes.
+
+2. **Back up your data.** On first startup, the new version may automatically
+   migrate internal metadata. Once this happens, rolling back to the previous
+   version may produce errors. Create a backup or snapshot before upgrading,
+   especially for production instances. See
+   [Backup and restore](/docs/operations/backup/) for details.
+
+## Upgrade steps
+
+### Docker
+
+Pull the latest image and restart the container, pointing to the same data
+volume:
+
+```shell
+docker pull questdb/questdb:latest
+```
+
+Then recreate your container with the new image, using the same volume mount for
+your QuestDB root directory:
+
+```shell
+docker stop questdb
+docker rm questdb
+docker run -d --name questdb \
+  -p 9000:9000 -p 9009:9009 -p 8812:8812 \
+  -v /path/to/questdb-data:/var/lib/questdb \
+  questdb/questdb:latest
+```
+
+Replace `/path/to/questdb-data` with the path to your existing data directory.
+
+### Binaries
+
+1. Stop the running QuestDB process.
+2. Download the new binary from the
+   [GitHub releases page](https://github.com/questdb/questdb/releases) (or
+   build from source).
+3. Replace the old binary with the new one.
+4. Start QuestDB, pointing to the same root directory.
+
+## QuestDB Enterprise
+
+:::tip QuestDB Enterprise BYOC
+If you are a QuestDB Enterprise BYOC customer, upgrades are managed for you. See
+[QuestDB Enterprise BYOC](#questdb-enterprise-byoc) below.
+:::
+
+The upgrade process for Enterprise is identical: replace the binary or pull the
+new image, then restart.
+
+The difference is how you obtain the new version:
+
+- **Binaries**: download from the SFTP or distribution channel provided by
+  QuestDB during onboarding.
+- **Docker**: pull from the Enterprise ECR registry that was whitelisted for your
+  AWS account.
+
+If you are unsure where to get the latest Enterprise version, contact
+[support@questdb.com](mailto:support@questdb.com).
+
+### Replication: upgrade order
+
+When running QuestDB Enterprise with replication, **upgrade all replicas before
+upgrading the primary**.
+
+The primary may write WAL segments containing new metadata formats to the object
+store. If a replica running an older version encounters metadata it does not
+recognize, it will error. Upgrading replicas first ensures they can handle any
+new metadata the primary produces after its upgrade.
+
+### QuestDB Enterprise BYOC
+
+For QuestDB Enterprise BYOC customers, QuestDB manages the upgrade process. The
+QuestDB team will reach out to coordinate when a new version is available. If
+you would like to upgrade sooner, contact
+[support@questdb.com](mailto:support@questdb.com).

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -664,6 +664,7 @@ module.exports = {
       label: "Operations",
       type: "category",
       items: [
+        "operations/upgrade",
         "operations/backup",
         "operations/logging-metrics",
         "operations/monitoring-alerting",


### PR DESCRIPTION
## Summary

- New page under Operations explaining how to upgrade QuestDB to a newer version (Docker and binaries)
- Covers open source, Enterprise (with replication upgrade order), and Enterprise BYOC
- Cross-links from Quick start and Upgrade to Enterprise pages