### PR TITLE
Fix broken import screenshot on ingestion overview

### DIFF
--- a/documentation/ingestion/overview.md
+++ b/documentation/ingestion/overview.md
@@ -85,7 +85,7 @@ For bulk imports or one-time data loads, use the
 <Screenshot
   alt="Screenshot of the UI for import"
   height={535}
-  src="images/docs/console/import-ui.webp"
+  src="images/docs/console/import-csv.webp"
   width={800}
 />
 


### PR DESCRIPTION
## Summary

- PR #399 deleted `import-ui.webp` but left the `<Screenshot>` reference in `ingestion/overview.md`, causing a broken image on `/docs/ingestion/overview/`
- Updated the reference to point at the existing `import-csv.webp`