### PR TITLE
Add DECLARE with Grafana time range recipe

### DIFF
--- a/documentation/cookbook/integrations/grafana/declare-time-range.md
+++ b/documentation/cookbook/integrations/grafana/declare-time-range.md
@@ -1,0 +1,111 @@
+---
+title: Use Grafana time range in DECLARE variables
+sidebar_label: DECLARE with time range
+description: Pass Grafana's dashboard time range into QuestDB DECLARE variables for parameterized queries
+---
+
+Pass Grafana's dashboard time range into QuestDB `DECLARE` variables.
+This is useful when you combine time range filtering with other declared
+parameters, override
+[parameterized views](/docs/concepts/views/#parameterized-views), or derive
+additional time boundaries from the dashboard range.
+
+## Problem
+
+The QuestDB Grafana plugin provides `$__fromTime` and `$__toTime` macros,
+but they expand to `cast(... as timestamp)`, which `DECLARE` does not
+support:
+
+```sql
+-- What you write
+DECLARE @from := $__fromTime, @to := $__toTime
+SELECT * FROM trades WHERE timestamp >= @from AND timestamp <= @to;
+
+-- What the plugin sends to QuestDB (fails)
+DECLARE @from := cast(1654380000000000 as timestamp), ...
+-- Error: table and column names that are SQL keywords have to be
+-- enclosed in double quotes, such as "cast"
+```
+
+## Solution
+
+Use `$__from` and `$__to` instead. These are
+[Grafana global variables](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#global-variables)
+that expand to plain epoch **milliseconds**, which `DECLARE` accepts.
+
+Convert milliseconds to the precision your table uses:
+
+- **TIMESTAMP** (microseconds): multiply by `1000`
+- **TIMESTAMP_NS** (nanoseconds): multiply by `1000000`
+
+```sql title="TIMESTAMP table (microseconds)"
+DECLARE
+  @from := $__from * 1000,
+  @to := $__to * 1000,
+  @symbol := 'BTC-USDT'
+SELECT timestamp, symbol, avg(price) AS avg_price
+FROM trades
+WHERE symbol = @symbol
+  AND timestamp >= @from
+  AND timestamp <= @to
+SAMPLE BY $__interval;
+```
+
+```sql title="TIMESTAMP_NS table (nanoseconds)"
+DECLARE
+  @from := $__from * 1000000,
+  @to := $__to * 1000000,
+  @symbol := 'EURUSD'
+SELECT timestamp, symbol, avg(price) AS avg_price
+FROM fx_trades
+WHERE symbol = @symbol
+  AND timestamp >= @from
+  AND timestamp <= @to
+SAMPLE BY $__interval;
+```
+
+No `cast()` is needed when the multiplier matches the table's timestamp
+precision. QuestDB compares the `LONG` value directly against the timestamp
+column.
+
+### Using cast as a safety net
+
+If you are unsure whether your table uses `TIMESTAMP` or `TIMESTAMP_NS`,
+you can multiply by `1000` (microseconds) and wrap the comparison in
+`cast(... AS timestamp)`. QuestDB auto-promotes `TIMESTAMP` to
+`TIMESTAMP_NS` when comparing against a nanosecond column, so this works
+for both types:
+
+```sql title="Works for both TIMESTAMP and TIMESTAMP_NS tables"
+DECLARE
+  @from := $__from * 1000,
+  @to := $__to * 1000
+SELECT timestamp, avg(price) AS avg_price
+FROM fx_trades
+WHERE timestamp >= cast(@from AS timestamp)
+  AND timestamp <= cast(@to AS timestamp)
+SAMPLE BY $__interval;
+```
+
+## When to use this instead of `$__timeFilter`
+
+`$__timeFilter(timestamp)` is simpler for straightforward queries:
+
+```sql
+SELECT timestamp, price FROM trades
+WHERE $__timeFilter(timestamp)
+SAMPLE BY $__interval;
+```
+
+The `DECLARE` approach is needed when:
+
+- You combine the time range with other `DECLARE` variables in a single block
+- You override a parameterized view whose time range variables must be set
+- You derive additional time boundaries from the dashboard range
+  (for example, a lookback window for a moving average)
+
+:::info Related documentation
+- [DECLARE](/docs/query/sql/declare/)
+- [Parameterized views](/docs/concepts/views/#parameterized-views)
+- [Grafana integration](/docs/integrations/visualization/grafana/)
+:::

--- a/documentation/integrations/visualization/grafana.md
+++ b/documentation/integrations/visualization/grafana.md
@@ -100,36 +100,66 @@ optimizations, we can lower this rate for greater fluidity.
 To learn how, see our
 [blog post](/blog/increase-grafana-refresh-rate-frequency/).
 
-## Global variables
+## Query macros
 
-Use
-[global variables](https://grafana.com/docs/grafana/latest/variables/variable-types/global-variables/#global-variables)
-to simplify queries with dynamic elements such as date range filters.
+The QuestDB Grafana plugin provides macros that are expanded before the query
+is sent to QuestDB. Use them to inject the dashboard time range and dynamic
+intervals into your SQL.
 
-### `$__timeFilter(timestamp)`
+### `$__timeFilter(columnName)`
 
-This variable allows filtering results by sending a start-time and end-time to
-QuestDB. This expression evaluates to:
+Filters a timestamp column to the panel's time range:
 
 ```questdb-sql
-timestamp BETWEEN
-    '2018-02-01T00:00:00Z' AND '2018-02-28T23:59:59Z'
+-- expands to
+columnName >= cast(1706263425598000 as timestamp)
+  AND columnName <= cast(1706285057560000 as timestamp)
 ```
 
-### `$__interval`
+### `$__fromTime` / `$__toTime`
 
-This variable calculates a dynamic interval based on the time range applied to
-the dashboard. By using this function, the sampling interval changes
-automatically as the user zooms in and out of the panel.
+Start and end of the panel's time range, each expanding to a
+`cast(... as timestamp)` expression. Useful in `WHERE` clauses and
+arithmetic, but cannot be used inside `DECLARE` blocks because the parser
+does not support `cast` in that context. See the
+[DECLARE with time range](/docs/cookbook/integrations/grafana/declare-time-range/)
+recipe for a workaround.
 
-```questdb-sql title="An example of $__interval"
+### `$__sampleByInterval`
+
+Dynamic interval for `SAMPLE BY`, using QuestDB time units
+(`s`, `T` for milliseconds, `h`, `d`). The interval adjusts automatically
+as the user zooms in and out of the panel.
+
+### `$__conditionalAll(condition, $templateVar)`
+
+Returns `condition` when the template variable has a specific selection,
+or `1=1` when "All" is selected. Useful for optional `WHERE` filters:
+
+```questdb-sql
+SELECT timestamp, symbol, price
+FROM trades
+WHERE $__timeFilter(timestamp)
+  AND $__conditionalAll(symbol = '$symbol', $symbol);
+```
+
+```questdb-sql title="Example: time-filtered SAMPLE BY query"
 SELECT
   timestamp AS time,
   avg(price) AS avg_price
 FROM trades
 WHERE $__timeFilter(timestamp)
-SAMPLE BY $__interval;
+SAMPLE BY $__sampleByInterval;
 ```
+
+## Grafana global variables
+
+Grafana also provides
+[global variables](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#global-variables)
+that are interpolated before the query reaches the plugin. The most useful
+ones for QuestDB are `$__from` and `$__to`, which expand to the dashboard
+time range as epoch milliseconds. These are plain numbers and can be used in
+`DECLARE` blocks after converting to the right precision.
 
 ## See also
 

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -941,6 +941,7 @@ module.exports = {
                   label: "Grafana",
                   collapsed: true,
                   items: [
+                    "cookbook/integrations/grafana/declare-time-range",
                     "cookbook/integrations/grafana/dynamic-table-queries",
                     "cookbook/integrations/grafana/read-only-user",
                     "cookbook/integrations/grafana/variable-dropdown",


### PR DESCRIPTION
## Summary

- New cookbook recipe: pass Grafana's dashboard time range into QuestDB `DECLARE` variables using `$__from`/`$__to` global variables (workaround for `$__fromTime`/`$__toTime` expanding to `cast()` which DECLARE does not support)
- Restructured the Grafana integration page: renamed "Global variables" to "Query macros" with proper documentation of all five plugin macros (`$__timeFilter`, `$__fromTime`, `$__toTime`, `$__sampleByInterval`, `$__conditionalAll`), and added a separate section for Grafana-level global variables