### PR TITLE
Fix raw-markdown interpolation for Java client version

### DIFF
--- a/plugins/raw-markdown/convert-components.js
+++ b/plugins/raw-markdown/convert-components.js
@@ -232,18 +232,21 @@ function convertConfigTable(content, docsPath) {
  * Converts <InterpolateReleaseData /> to actual version number
  * Fetches latest release version once and caches it
  */
-let cachedReleaseVersion = null
+const releaseCache = new Map()
 
-async function fetchReleaseVersion() {
-  if (cachedReleaseVersion) {
-    return cachedReleaseVersion
+async function fetchGitHubRelease(repo, { stripV = false } = {}) {
+  if (releaseCache.has(repo)) {
+    return releaseCache.get(repo)
   }
+
+  const url = `https://api.github.com/repos/${repo}/releases/latest`
+  const fallback = "latest"
 
   try {
     const https = require("https")
 
-    return new Promise((resolve, reject) => {
-      https.get("https://api.github.com/repos/questdb/questdb/releases/latest", {
+    const version = await new Promise((resolve) => {
+      https.get(url, {
         headers: { "User-Agent": "QuestDB-Docs" }
       }, (res) => {
         let data = ""
@@ -252,19 +255,31 @@ async function fetchReleaseVersion() {
         res.on("end", () => {
           try {
             const release = JSON.parse(data)
-            cachedReleaseVersion = release.tag_name || "latest"
-            resolve(cachedReleaseVersion)
+            let tag = release.tag_name || fallback
+            if (stripV) tag = tag.replace(/^v/, '')
+            resolve(tag)
           } catch (e) {
-            resolve("latest")
+            resolve(fallback)
           }
         })
       }).on("error", () => {
-        resolve("latest")
+        resolve(fallback)
       })
     })
+
+    releaseCache.set(repo, version)
+    return version
   } catch (e) {
-    return "latest"
+    return fallback
   }
+}
+
+async function fetchReleaseVersion() {
+  return fetchGitHubRelease("questdb/questdb")
+}
+
+async function fetchJavaClientVersion() {
+  return fetchGitHubRelease("questdb/java-questdb-client", { stripV: true })
 }
 
 function convertInterpolateReleaseData(content, releaseVersion) {
@@ -297,6 +312,30 @@ function convertInterpolateReleaseData(content, releaseVersion) {
 
     // Fallback: just remove the component
     return '\n\n<!-- InterpolateReleaseData component removed -->\n\n'
+  })
+}
+
+function convertInterpolateJavaClientVersion(content, javaClientVersion) {
+  return replaceComponent(content, 'InterpolateJavaClientVersion', (match) => {
+    let renderTextMatch = match.fullMatch.match(/renderText=\{[^(]*\([^)]*\)\s*=>\s*\(([\s\S]*?)\)\s*\}/);
+
+    if (!renderTextMatch) {
+      renderTextMatch = match.fullMatch.match(/renderText=\{[^(]*\([^)]*\)\s*=>\s*\{\s*return\s*\(([\s\S]*?)\)\s*\}\s*\}/);
+    }
+
+    if (renderTextMatch) {
+      let extracted = renderTextMatch[1].trim();
+
+      extracted = extracted.replace(/\$?\{release\.name\}/g, javaClientVersion);
+      extracted = extracted.replace(/\$?\{release\.tag_name\}/g, javaClientVersion);
+
+      extracted = extracted.replace(/\{`/g, '');
+      extracted = extracted.replace(/`\}/g, '');
+
+      return `\n\n${extracted}\n\n`;
+    }
+
+    return '\n\n<!-- InterpolateJavaClientVersion component removed -->\n\n'
   })
 }
 
@@ -449,11 +488,13 @@ function convertClients(content) {
 async function convertAllComponents(content, currentFileDir, docsRoot, repoExamples = {}) {
   let processed = content
 
-  // Get release version once
+  // Get release versions once
   const releaseVersion = await fetchReleaseVersion()
+  const javaClientVersion = await fetchJavaClientVersion()
 
   // Convert components in order
   processed = convertInterpolateReleaseData(processed, releaseVersion)
+  processed = convertInterpolateJavaClientVersion(processed, javaClientVersion)
   processed = convertRemoteRepoExample(processed, repoExamples)
   processed = convertILPClientsTable(processed)
   processed = convertClients(processed)


### PR DESCRIPTION
## Summary

- The `raw-markdown` postBuild plugin handles `<InterpolateReleaseData>` (QuestDB server version) but not `<InterpolateJavaClientVersion>` (Java client Maven artifact version). This means the generated `.md` files for pages using that component have unresolved JSX instead of the actual version number, breaking the "Copy as Markdown" feature and confusing LLM agents that consume the `.md` URLs.
- Adds a converter for `<InterpolateJavaClientVersion>` that fetches the latest release from `questdb/java-questdb-client` and interpolates it, matching what the Docusaurus plugin does at build time.
- Refactors the GitHub release fetching into a shared `fetchGitHubRelease()` with a cache Map, so adding more repos in the future is trivial.