### PR TITLE
Update changelog with May 12-15 entries, fix skill path resolution

### DIFF
--- a/.claude/skills/docs-changelog/SKILL.md
+++ b/.claude/skills/docs-changelog/SKILL.md
@@ -19,12 +19,14 @@ same work, before reporting the task as done.
 
 ### Step 1: Determine the date range
 
-1. Read `documentation/changelog.mdx` and find the most recent month header
+1. Locate the changelog by globbing for `**/changelog.mdx` under the repo
+   root. Use the resolved absolute path for all subsequent reads and writes.
+2. Read the file and find the most recent month header
    (format: `## Month YYYY`).
-2. If the changelog does not exist or has no date, use 1 month ago. No
+3. If the changelog does not exist or has no date, use 1 month ago. No
    exceptions.
-3. Store this as `SINCE_DATE`.
-4. Never go further back than the calculated date without user confirmation.
+4. Store this as `SINCE_DATE`.
+5. Never go further back than the calculated date without user confirmation.
 
 ### Step 2: Get commits since that date
 
@@ -145,8 +147,10 @@ If a file does not exist, describe the change without a link:
 Prepend the new entry after the frontmatter and intro paragraph but before
 existing month entries.
 
-The changelog file is `documentation/changelog.mdx` (NOT
-`documentation/docs/changelog.mdx`).
+The changelog file is `documentation/changelog.mdx` relative to the
+repository root. Locate it by globbing for `**/changelog.mdx` under the
+content directory if needed. Read the file before writing to confirm the
+resolved path is correct.
 
 ### Step 9: Build to validate links (mandatory)
 

--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -14,9 +14,11 @@ This page tracks significant updates to the QuestDB documentation.
 
 - [Upgrade QuestDB](/docs/operations/upgrade/) - Guide for upgrading QuestDB versions
 - [Table/column versioning](/docs/concepts/deep-dive/root-directory-structure/) - Added versioning info to root directory structure
+- [DECLARE with Grafana time range](/docs/cookbook/integrations/grafana/declare-time-range/) - Pass Grafana dashboard time range into QuestDB `DECLARE` variables
 
 ### Reference
 
+- Added [`ntile()`](/docs/query/functions/window-functions/reference/#ntile), [`cume_dist()`](/docs/query/functions/window-functions/reference/#cume_dist), and [`nth_value()`](/docs/query/functions/window-functions/reference/#nth_value) window functions
 - Fixed `timestamp_ns` valid range documentation
 - Added precise microsecond-grained timestamp examples for PHP clients
 - Fixed PIVOT syntax: removed redundant `FOR` from multiple pivot statements
@@ -33,6 +35,8 @@ This page tracks significant updates to the QuestDB documentation.
 - [PIVOT](/docs/query/sql/pivot/) - Fixed examples to use demo server data
 - [Array functions](/docs/query/functions/array/) - Improved page with demo examples
 - [TICK syntax](/docs/query/operators/tick/) - Documented imprecise date support
+- [SAMPLE BY](/docs/query/sql/sample-by/) - Documented `FILL(PREV(col))` fast-path syntax and updated FROM-TO limitations for keyed queries
+- [Grafana integration](/docs/integrations/visualization/grafana/) - Restructured query macros section with full documentation of all five plugin macros
 - [Configuration reference](/docs/configuration/overview/) - Revamped into 17 dedicated per-subsystem pages with epigraph-style property listings
 
 ## April 2026


### PR DESCRIPTION
## Summary

- Add recent documentation changes to May 2026 changelog: ntile/cume_dist/nth_value window functions, SAMPLE BY FILL fast-path syntax, DECLARE with Grafana time range recipe, and Grafana query macros restructure
- Fix changelog skill to glob for the changelog file before reading/writing, preventing path misresolution across different working directories