### PR TITLE
Add Order Flow Imbalance (OFI) cookbook recipe

### DIFF
--- a/documentation/cookbook/demo-data-schema.md
+++ b/documentation/cookbook/demo-data-schema.md
@@ -23,6 +23,10 @@ The demo instance provides two independent datasets:
 
 The FX dataset contains simulated foreign exchange market data for 30 currency pairs. We fetch real reference prices from Yahoo Finance every few seconds, but all order book levels and price updates are generated algorithmically based on these reference prices.
 
+:::note Simulation realism
+Reference prices are real, synced from Yahoo Finance every few seconds. Between syncs, individual quote prices per venue are generated within realistic pip distances from the reference, but they are not real market quotes. Volumes (`bid_volume`, `ask_volume`, `quantity`) are entirely fabricated and tend to be larger than what you would see on a production feed. Recipes that depend on volume magnitudes (VPIN, OFI, volume profile) will produce structurally correct output, but absolute numbers should not be compared to published research or live market benchmarks.
+:::
+
 ### core_price table
 
 The `core_price` table contains individual FX price updates from various liquidity providers. Each row represents a bid/ask quote update for a specific currency pair from a specific ECN.

--- a/documentation/cookbook/sql/finance/aggressor-volume-imbalance.md
+++ b/documentation/cookbook/sql/finance/aggressor-volume-imbalance.md
@@ -35,4 +35,6 @@ The imbalance ranges from -100% (all sell) to +100% (all buy), with 0% indicatin
 :::info Related documentation
 - [CASE expressions](/docs/query/sql/case/)
 - [Aggregation functions](/docs/query/functions/aggregation/)
+- [Order Flow Imbalance (OFI) recipe](order-flow-imbalance.md)
+- [VPIN recipe](vpin.md)
 :::

--- a/documentation/cookbook/sql/finance/index.md
+++ b/documentation/cookbook/sql/finance/index.md
@@ -52,6 +52,7 @@ Analyze trading activity and order flow dynamics.
 | [Volume Profile](volume-profile.md) | Volume distribution by price level |
 | [Volume Spike](volume-spike.md) | Detect abnormal volume |
 | [Aggressor Imbalance](aggressor-volume-imbalance.md) | Buy vs sell pressure |
+| [Order Flow Imbalance](order-flow-imbalance.md) | Quote-based top-of-book buying/selling pressure |
 | [VPIN](vpin.md) | Volume-synchronized informed trading probability |
 
 ## Risk Metrics

--- a/documentation/cookbook/sql/finance/obv.md
+++ b/documentation/cookbook/sql/finance/obv.md
@@ -1,6 +1,6 @@
 ---
 title: OBV (On-Balance Volume)
-sidebar_label: OBV
+sidebar_label: On-Balance Volume
 description: Calculate On-Balance Volume to track cumulative buying and selling pressure using volume flow
 ---
 

--- a/documentation/cookbook/sql/finance/order-flow-imbalance.md
+++ b/documentation/cookbook/sql/finance/order-flow-imbalance.md
@@ -1,0 +1,149 @@
+---
+title: Order Flow Imbalance (OFI)
+sidebar_label: Order flow imbalance
+description: Measure top-of-book buying and selling pressure from L1 quote updates using the Cont-Kukanov-Stoikov definition.
+---
+
+Quantify net buying pressure at the top of the book from quote-level updates. Order Flow Imbalance (OFI), introduced by Cont, Kukanov, and Stoikov (2014), captures the signed contribution of every L1 quote change (bid arrivals, cancellations, and resizing) into a single number per venue or per symbol.
+
+Unlike trade-based imbalance metrics ([aggressor volume imbalance](aggressor-volume-imbalance.md), [VPIN](vpin.md)), OFI is computed from **quotes, not trades**. It reacts to liquidity providers reshaping the book before any execution happens, making it a leading indicator of short-term price changes on most liquid instruments.
+
+## Problem
+
+You want to measure top-of-book pressure tick by tick, separating buy-side intent (rising bids, growing bid size, ask cancellations) from sell-side intent. Trade-based metrics miss everything that happens between executions. Limit order placement and cancellation at the best price are often the earliest signal of where the market is about to move.
+
+## Solution
+
+For each consecutive pair of quote updates on a given venue, compute the signed change at the best bid and the best ask, then take their difference. Sum the per-event contributions into time buckets.
+
+```questdb-sql demo title="OFI per ECN, bucketed at 1 second"
+WITH quote_lag AS (
+    SELECT
+        timestamp,
+        symbol,
+        ecn,
+        bid_price, bid_volume, ask_price, ask_volume,
+        lag(bid_price)  OVER w AS prev_bid_price,
+        lag(bid_volume) OVER w AS prev_bid_volume,
+        lag(ask_price)  OVER w AS prev_ask_price,
+        lag(ask_volume) OVER w AS prev_ask_volume
+    FROM core_price
+    WHERE symbol = 'EURUSD'
+      AND timestamp IN '$yesterday'
+    WINDOW w AS (PARTITION BY symbol, ecn ORDER BY timestamp)
+),
+contributions AS (
+    SELECT
+        timestamp,
+        symbol,
+        ecn,
+        CASE
+            WHEN bid_price > prev_bid_price THEN bid_volume
+            WHEN bid_price < prev_bid_price THEN -prev_bid_volume
+            ELSE bid_volume - prev_bid_volume
+        END
+        -
+        CASE
+            WHEN ask_price < prev_ask_price THEN ask_volume
+            WHEN ask_price > prev_ask_price THEN -prev_ask_volume
+            ELSE ask_volume - prev_ask_volume
+        END AS ofi_event
+    FROM quote_lag
+    WHERE prev_bid_price IS NOT NULL
+)
+SELECT
+    timestamp,
+    symbol,
+    ecn,
+    sum(ofi_event) AS ofi
+FROM contributions
+SAMPLE BY 1s;
+```
+
+## How it works
+
+### Step 1: Lag each quote against its previous update
+
+The `quote_lag` CTE attaches the previous bid/ask price and volume to every row, partitioned by `symbol` and `ecn` so each venue is compared against its own history. The named window `w` is reused across the four `lag` calls to keep the query readable.
+
+### Step 2: Apply the OFI event rule
+
+Each row contributes a signed value derived from how the best bid and best ask changed since the last quote, following Cont-Kukanov-Stoikov.
+
+**Bid side:**
+
+- Bid price went up: a buyer raised the best bid. The full new size enters as positive pressure.
+- Bid price went down: the previous bid was pulled or executed away. The full old size leaves as negative pressure.
+- Bid price unchanged: it is a size update. The contribution is `bid_volume - prev_bid_volume`.
+
+**Ask side** mirrors the bid logic with inverted price comparisons. A lower ask is buy pressure (sellers moving toward buyers). A higher ask is sell pressure.
+
+The event-level OFI is `bid contribution − ask contribution`. Positive means net buying pressure, negative means net selling pressure.
+
+### Step 3: Aggregate into time buckets
+
+`SAMPLE BY 1s` sums the per-event contributions into one-second buckets. The bucket size is a tuning knob: it should match the horizon over which you want to relate OFI to price moves. Use 100ms (`SAMPLE BY 100T`) for microstructure work, or longer windows for slower strategies.
+
+## Interpreting results
+
+Sign indicates direction, magnitude indicates intensity. Across a sample of healthy quote flow, OFI should oscillate around zero with the residual being the predictive signal. A persistent one-sided OFI over many buckets indicates a directional regime, either a genuine trend or a market maker stepping back from one side of the book.
+
+OFI typically leads same-bucket mid-price changes on liquid pairs. To validate that your data and parameters produce a usable signal, compute the correlation between OFI and the mid-price change over the same bucket. On real markets this is typically 0.3 to 0.7 for major FX pairs.
+
+## Consolidated OFI across venues
+
+To get a single OFI series across all ECNs, wrap the per-ECN events and sum:
+
+```questdb-sql demo title="Consolidated OFI across ECNs"
+WITH quote_lag AS (
+    SELECT
+        timestamp,
+        symbol,
+        ecn,
+        bid_price, bid_volume, ask_price, ask_volume,
+        lag(bid_price)  OVER w AS prev_bid_price,
+        lag(bid_volume) OVER w AS prev_bid_volume,
+        lag(ask_price)  OVER w AS prev_ask_price,
+        lag(ask_volume) OVER w AS prev_ask_volume
+    FROM core_price
+    WHERE symbol = 'EURUSD'
+      AND timestamp IN '$yesterday'
+    WINDOW w AS (PARTITION BY symbol, ecn ORDER BY timestamp)
+),
+contributions AS (
+    SELECT
+        timestamp,
+        symbol,
+        CASE
+            WHEN bid_price > prev_bid_price THEN bid_volume
+            WHEN bid_price < prev_bid_price THEN -prev_bid_volume
+            ELSE bid_volume - prev_bid_volume
+        END
+        -
+        CASE
+            WHEN ask_price < prev_ask_price THEN ask_volume
+            WHEN ask_price > prev_ask_price THEN -prev_ask_volume
+            ELSE ask_volume - prev_ask_volume
+        END AS ofi_event
+    FROM quote_lag
+    WHERE prev_bid_price IS NOT NULL
+)
+SELECT timestamp, symbol, sum(ofi_event) AS ofi
+FROM contributions
+SAMPLE BY 1s;
+```
+
+This treats each ECN's L1 as an independent book and sums their pressures. It is a good proxy for aggregate flow, but it is not the same as OFI on a virtual consolidated top-of-book (which would require building the best bid/ask across venues first, then computing OFI on that series).
+
+## Tuning parameters
+
+- **Bucket size** (`SAMPLE BY 1s`): match this to your prediction horizon. The correlation with mid-change is highest when the OFI bucket and the return horizon are aligned.
+- **Symbol filter**: OFI is computed per `(symbol, ecn)`. The `WHERE` clause keeps the example fast on the demo. Drop it to compute OFI across all symbols at once. The `PARTITION BY symbol, ecn` in the window handles separation.
+- **Time window**: `$yesterday` covers a full session. For intraday work, narrow to a specific hour to keep result sizes manageable.
+
+:::info Related documentation
+- [Window functions](/docs/query/functions/window-functions/overview/)
+- [Aggressor volume imbalance recipe](aggressor-volume-imbalance.md)
+- [VPIN recipe](vpin.md)
+- [Cont, Kukanov & Stoikov (2014) - The Price Impact of Order Book Events](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=1712822)
+:::

--- a/documentation/cookbook/sql/finance/vpin.md
+++ b/documentation/cookbook/sql/finance/vpin.md
@@ -152,5 +152,6 @@ Compare VPIN time series across ECNs. An ECN that shows elevated VPIN while othe
 :::info Related documentation
 - [Window functions](/docs/query/functions/window-functions/overview/)
 - [Aggressor volume imbalance recipe](aggressor-volume-imbalance.md)
+- [Order Flow Imbalance (OFI) recipe](order-flow-imbalance.md)
 - [ECN scorecard recipe](ecn-scorecard.md)
 :::

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -850,6 +850,7 @@ module.exports = {
                         "cookbook/sql/finance/volume-profile",
                         "cookbook/sql/finance/volume-spike",
                         "cookbook/sql/finance/aggressor-volume-imbalance",
+                        "cookbook/sql/finance/order-flow-imbalance",
                         "cookbook/sql/finance/vpin",
                       ],
                     },


### PR DESCRIPTION
## Summary

- New cookbook recipe for Order Flow Imbalance (OFI) using the Cont-Kukanov-Stoikov definition, computed from L1 quote changes on `core_price`
- Includes per-ECN and consolidated-across-ECNs variants
- Cross-links all three order flow recipes: aggressor imbalance, OFI, and VPIN
- Adds simulation realism note to demo data schema page (prices are real-anchored but volumes are fabricated)
- Expands sidebar labels for OBV and OFI for discoverability