### PR TITLE
Fix systemd service example

### DIFF
--- a/documentation/deployment/systemd.md
+++ b/documentation/deployment/systemd.md
@@ -1,12 +1,12 @@
 ---
 title: Launch QuestDB with systemd
 sidebar_label: systemd
-description: This document describes how to launch QuestBD using systemd.
+description: This document describes how to launch QuestDB using systemd.
 ---
 
 Use systemd to run QuestDB as a system or user service. This guide will
 demonstrate an initial configuration which you can use as the basis for your
-installation scripts. It will also demonstrate how to setup and start a QuestDB
+installation scripts. It will also demonstrate how to set up and start a QuestDB
 systemd service.
 
 ## Prerequisites
@@ -37,6 +37,7 @@ export PATH=$JAVA_HOME/bin:$PATH
 # Download and set up QuestDB
 curl -s https://dl.questdb.io/snapshots/questdb-latest-no-jre-bin.tar.gz -o questdb.tar.gz
 mkdir -p ~/questdb/binary
+mkdir -p ~/bin ~/var/lib/questdb
 tar -xzf questdb.tar.gz -C ~/questdb/binary --strip-components 1
 mv ~/questdb/binary/questdb.jar ~/bin/
 ```
@@ -45,7 +46,7 @@ mv ~/questdb/binary/questdb.jar ~/bin/
 
 Your QuestDB configuration is done in a `server.conf` file. The `server.conf`
 file is populated with safe defaults on first startup if it does not exist. It
-is common for user's of QuestDB to stick with the default configuration.
+is common for users of QuestDB to stick with the default configuration.
 However, should you choose to update your own and serve it via a scripted method
 or similar, you may do so.
 
@@ -76,14 +77,15 @@ Restart=always
 RestartSec=2
 # Adjust java path to match requirements of a given distro
 ExecStart=/home/[USER_NAME]/jdk/bin/java \
+-XX:+UnlockExperimentalVMOptions \
+-XX:+AlwaysPreTouch \
+-XX:+UseParallelGC \
+-DQuestDB-Runtime-66535 \
+-Dcontainerized=false \
+-ea -Dnoebug \
 --add-exports java.base/jdk.internal.math=io.questdb \
 -p /home/[USER_NAME]/bin/questdb.jar \
 -m io.questdb/io.questdb.ServerMain \
--DQuestDB-Runtime-66535 \
--ea -Dnoebug \
--XX:+UnlockExperimentalVMOptions \
--XX:+AlwaysPreTouch \
--XX:+UseParallelOldGC \
 -d /home/[USER_NAME]/var/lib/questdb
 
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
## Summary
- update the systemd ExecStart example so JVM options are passed before the module path/main module
- replace UseParallelOldGC with UseParallelGC and set -Dcontainerized=false for the non-containerized service example
- create ~/bin and ~/var/lib/questdb in the setup snippet so first-time installs have the required paths
- fix a few small wording typos on the page

## Verification
- `source /Users/wy/.nvm/nvm.sh && nvm exec 22.22.2 npx --yes yarn@1.22.22 install --frozen-lockfile`
- `source /Users/wy/.nvm/nvm.sh && nvm exec 22.22.2 npx --yes yarn@1.22.22 build`
- `git diff --check`

Fixes questdb/questdb#4265
Related to questdb/documentation#224 and questdb/questdb#4258