### PR TITLE
Document gzip support for ILP/HTTP and Telegraf

### DIFF
--- a/documentation/ingestion/ilp/overview.md
+++ b/documentation/ingestion/ilp/overview.md
@@ -90,6 +90,18 @@ connection failures. However, while HTTP is recommended, TCP has slightly lower
 overhead than HTTP and may be useful in high-throughput scenarios in
 high-latency networks.
 
+### Request compression
+
+The HTTP transport accepts gzip-compressed payloads. Third-party tools that
+send ILP over HTTP, such as Telegraf, can set `Content-Encoding: gzip` to
+reduce bandwidth usage. This is most useful when sending text-heavy data
+(logs, documents) or when the client is bandwidth-constrained. The trade-off
+is some CPU overhead for compression on the client and decompression on the
+server.
+
+Compression is not currently exposed by the official QuestDB ILP clients,
+which send uncompressed payloads.
+
 ## Client-Side Configuration
 
 Clients connect to a QuestDB using ILP via a configuration string. Configuration

--- a/documentation/ingestion/message-brokers/telegraf.md
+++ b/documentation/ingestion/message-brokers/telegraf.md
@@ -95,8 +95,10 @@ load configuration files from and paste the following example:
 [[outputs.influxdb_v2]]
 # Use InfluxDB Line Protocol to write metrics to QuestDB
   urls = ["http://localhost:9000"]
-# Disable gzip compression
-  content_encoding = "identity"
+# QuestDB 9.1.0 and later accept gzip-compressed payloads, so Telegraf's
+# default gzip encoding works out of the box. Uncomment the line below to
+# disable gzip if you are on an older QuestDB version.
+#  content_encoding = "identity"
 
 # -- INPUT PLUGINS -- #
 [[inputs.cpu]]


### PR DESCRIPTION
## Summary

- ILP overview: new "Request compression" subsection noting that the HTTP transport accepts gzip-compressed payloads, when it's useful, and that the official QuestDB ILP clients don't send compressed.
- Telegraf: keep the `content_encoding = "identity"` workaround commented out, with a note that QuestDB 9.1.0+ accepts Telegraf's default gzip encoding. Uncomment for older QuestDB versions.

Server-side support shipped in [questdb/questdb#6165](https://github.com/questdb/questdb/pull/6165) (QuestDB 9.1.0).