### PR TITLE
Rename agent skill repo references to questdb/skills

### DIFF
--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -8,6 +8,22 @@ description: Recent updates and improvements to the QuestDB documentation.
 
 This page tracks significant updates to the QuestDB documentation.
 
+## June 2026
+
+### Releases
+
+- [9.4.2](https://questdb.com/release-notes/) - Released June 9, 2026
+- [9.4.1](https://questdb.com/release-notes/) - Released June 3, 2026
+
+### Reference
+
+- Added [`array_agg()`](/docs/query/functions/aggregation/#array_agg) aggregate function, covering scalar and array input forms, `SAMPLE BY` with FILL, and NULL handling
+- Documented the [`twap()`](/docs/query/functions/aggregation/#twap) designated-timestamp limitation: the timestamp argument must be the table's designated timestamp
+
+### Updated
+
+- [systemd service example](/docs/deployment/systemd/) - Updated the Java requirement from 17 to 25 across deployment and quick-start prerequisites
+
 ## May 2026
 
 ### Releases

--- a/documentation/getting-started/ai-coding-agents.mdx
+++ b/documentation/getting-started/ai-coding-agents.mdx
@@ -50,7 +50,7 @@ Claude Code: I'll query the QuestDB REST API to list your tables.
 
 ## QuestDB agent skill
 
-The <a href="https://github.com/questdb/questdb-agent-skill" target="_blank">QuestDB agent skill</a> is an experimental skill for Claude Code and Codex. It embeds QuestDB-specific knowledge directly into the agent's context - SQL syntax, common mistakes, ingestion patterns, Grafana templates, and financial indicator recipes - so the agent can build complete data pipelines without searching the docs for every step. For topics not covered by the skill, the agent falls back to the online documentation automatically.
+The <a href="https://github.com/questdb/skills" target="_blank">QuestDB agent skill</a> is an experimental skill for Claude Code and Codex. It embeds QuestDB-specific knowledge directly into the agent's context - SQL syntax, common mistakes, ingestion patterns, Grafana templates, and financial indicator recipes - so the agent can build complete data pipelines without searching the docs for every step. For topics not covered by the skill, the agent falls back to the online documentation automatically.
 
 ### Installation
 
@@ -62,7 +62,7 @@ The <a href="https://github.com/questdb/questdb-agent-skill" target="_blank">Que
 <TabItem value="npx">
 
 ```shell
-npx skills add questdb/questdb-agent-skill
+npx skills add questdb/skills
 ```
 
 This installs the skill globally for Claude Code. To install it for a specific project only, run the command from the project directory with the `--local` flag.
@@ -71,7 +71,7 @@ This installs the skill globally for Claude Code. To install it for a specific p
 
 <TabItem value="manual">
 
-Copy the `questdb/` folder from the <a href="https://github.com/questdb/questdb-agent-skill" target="_blank">repository</a> into your skills directory:
+Copy the `questdb/` folder from the <a href="https://github.com/questdb/skills" target="_blank">repository</a> into your skills directory:
 
 **Claude Code:**
 - `~/.claude/skills/questdb/` - available in all projects


### PR DESCRIPTION
Updates references from `questdb/questdb-agent-skill` to `questdb/skills` ahead of renaming the GitHub repo.

- `npx skills add` install command
- the two repository links on the AI Coding Agents page

The `#questdb-agent-skill` heading anchor is left unchanged.