### PR TITLE
Update Java requirement from 17 to 25

### DIFF
--- a/documentation/deployment/systemd.md
+++ b/documentation/deployment/systemd.md
@@ -14,6 +14,7 @@ systemd service.
 The prerequisites for deploying QuestDB with systemd are:
 
 - A Unix machine supporting systemd
+- Java 25 (OpenJDK 25 or compatible distribution)
 
 ## Initial system configuration
 
@@ -27,11 +28,9 @@ user with appropriately scoped permissions.
 ```bash
 #!/bin/bash
 
-# Download and install the JDK
-curl -s https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz -o jdk.tar.gz
-mkdir -p ~/jdk
-tar -xzf jdk.tar.gz -C ~/jdk --strip-components=1
-export JAVA_HOME=~/jdk
+# Install OpenJDK 25
+sudo apt-get update && sudo apt-get install -y openjdk-25-jdk
+export JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64
 export PATH=$JAVA_HOME/bin:$PATH
 
 # Download and set up QuestDB
@@ -76,7 +75,7 @@ Type=simple
 Restart=always
 RestartSec=2
 # Adjust java path to match requirements of a given distro
-ExecStart=/home/[USER_NAME]/jdk/bin/java \
+ExecStart=/usr/lib/jvm/java-25-openjdk-amd64/bin/java \
 -XX:+UnlockExperimentalVMOptions \
 -XX:+AlwaysPreTouch \
 -XX:+UseParallelGC \

--- a/documentation/getting-started/quick-start-utils/_no-jre-prerequisites.partial.mdx
+++ b/documentation/getting-started/quick-start-utils/_no-jre-prerequisites.partial.mdx
@@ -10,7 +10,7 @@ This package does not embed Java.
 
 Use this if there is no package for your platform, such as ARM Linux.
 
-Requires local Java 17.
+Requires local Java 25.
 
 To check your installed version:
 
@@ -20,11 +20,11 @@ java -version
 
 If you do not have Java, install one of the following:
 
-- AdoptOpenJDK
+- Eclipse Temurin
 - Amazon Corretto
 - OpenJDK
 - Oracle Java
 
-Other Java distributions might work but are not tested regularly. For example, it is known that Azul Zing 17 is incompatible.
+Other Java distributions might work but are not tested regularly. For example, it is known that Azul Zing is incompatible.
 
-For environment variable, point `JAVA_HOME` to your Java 17 installation folder.
+For environment variable, point `JAVA_HOME` to your Java 25 installation folder.

--- a/documentation/query/functions/meta.md
+++ b/documentation/query/functions/meta.md
@@ -32,7 +32,7 @@ SELECT build();
 
 | build                                                                                              |
 | -------------------------------------------------------------------------------------------------- |
-| Build Information: QuestDB 7.3.5, JDK 17.0.7, Commit Hash 460b817b0a3705c5633619a8ef9efb5163f1569c |
+| Build Information: QuestDB 9.0.0, JDK 25, Commit Hash 460b817b0a3705c5633619a8ef9efb5163f1569c |
 
 ## current database, schema, or user
 


### PR DESCRIPTION
## Summary

- QuestDB core moved to JDK 25 in April 2026 (questdb/questdb#6980), but the docs still referenced Java 17
- Replace broken Oracle JDK 17 download in systemd guide with `apt install openjdk-25-jdk`
- Update no-JRE prerequisites partial from Java 17 to Java 25
- Update `build()` example output in meta functions page
- Rename AdoptOpenJDK to Eclipse Temurin (its successor)

Addresses feedback from #453 (comment).