### PR TITLE
Document custom root CA for the replication object store

### DIFF
--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -17,6 +17,8 @@ This page tracks significant updates to the QuestDB documentation.
 
 ### Reference
 
+- Documented the column wildcard with optional `EXCLUDE` list for column-level [`GRANT`](/docs/query/sql/acl/grant/#grant-on-all-columns-of-a-table) and [`REVOKE`](/docs/query/sql/acl/revoke/#revoke-from-all-columns-of-a-table) — `GRANT SELECT ON trades(*) TO user` grants every current column, and `EXCLUDE` omits specific ones
+- Documented custom root CA support for the replication object store: the `ca_cert_file` and `ca_builtin_roots` [connection-string parameters](/docs/high-availability/setup/#tls-with-a-private-or-self-signed-ca) trust a private, internal, or self-signed CA for S3, Azure Blob, and GCS stores
 - Added [`array_agg()`](/docs/query/functions/aggregation/#array_agg) aggregate function, covering scalar and array input forms, `SAMPLE BY` with FILL, and NULL handling
 - Documented the [`twap()`](/docs/query/functions/aggregation/#twap) designated-timestamp limitation: the timestamp argument must be the table's designated timestamp
 

--- a/documentation/configuration/database-replication.md
+++ b/documentation/configuration/database-replication.md
@@ -33,6 +33,10 @@ For a tuning guide, see the
 A configuration string for connecting to an object store. The format is
 `scheme::key1=value;key2=value2;…`. Ignored if replication is disabled.
 
+For a store fronted by a private, internal, or self-signed CA, the string also
+accepts the `ca_cert_file` and `ca_builtin_roots` TLS parameters. See
+[TLS with a private or self-signed CA](/docs/high-availability/setup/#tls-with-a-private-or-self-signed-ca).
+
 ### replication.role
 
 - **Default**: `none`

--- a/documentation/high-availability/setup.md
+++ b/documentation/high-availability/setup.md
@@ -101,7 +101,11 @@ cat <key>.json | base64
 replication.object.store=gcs::bucket=${BUCKET_NAME};root=/;credential=${BASE64_ENCODED_KEY};
 ```
 
-Alternatively, use `credential_path` to reference the key file directly.
+Alternatively, use `credential_path` to reference the key file directly, or
+supply a pre-obtained static OAuth `token` to skip the token exchange
+altogether. A static `token` is required when the store sits behind a private
+or intercepting CA; see
+[TLS with a private or self-signed CA](#tls-with-a-private-or-self-signed-ca).
 
 :::tip[Using Workload Identity]
 If your instance uses Workload Identity (GKE) or runs on a GCE VM with a service
@@ -130,7 +134,7 @@ replication.object.store=fs::root=/mnt/nfs_replication/final;atomic_write_dir=/m
 
 ### TLS with a private or self-signed CA
 
-By default, QuestDB trusts only the built-in Mozilla (webpki) root certificates
+By default, QuestDB trusts only the built-in Mozilla root certificates
 when connecting to an object store over HTTPS. Public AWS S3, Azure Blob, and
 GCS endpoints work out of the box, but a private or on-prem
 S3/Azure/GCS-compatible store fronted by an internal CA, a self-signed
@@ -163,8 +167,7 @@ is read and parsed at startup, so a missing or malformed PEM fails fast with an
   then fails every request with a certificate-trust error.
 - **No `;` in the path.** The connection string is split on `;` with no escape,
   so a certificate path must not contain a `;`. A parameter with no `=` (for
-  example a path truncated at a `;`) is now rejected at startup rather than
-  silently dropped.
+  example, a path truncated at a `;`) is rejected at startup.
 - **Data requests only.** The custom CA applies to object store data requests
   (read, write, list, delete). Dynamic credential and token fetches (S3
   IMDS/STS/assume-role and the GCS OAuth token endpoint) go through a separate

--- a/documentation/high-availability/setup.md
+++ b/documentation/high-availability/setup.md
@@ -128,6 +128,55 @@ mount to prevent write corruption.
 replication.object.store=fs::root=/mnt/nfs_replication/final;atomic_write_dir=/mnt/nfs_replication/scratch;
 ```
 
+### TLS with a private or self-signed CA
+
+By default, QuestDB trusts only the built-in Mozilla (webpki) root certificates
+when connecting to an object store over HTTPS. Public AWS S3, Azure Blob, and
+GCS endpoints work out of the box, but a private or on-prem
+S3/Azure/GCS-compatible store fronted by an internal CA, a self-signed
+certificate, or a TLS-intercepting proxy fails the TLS handshake. Two optional
+connection-string parameters add the trusted CA:
+
+- `ca_cert_file`: path to a PEM file holding one or more CA root certificates to
+  trust, in addition to the built-in roots. The file may hold a single
+  certificate or a bundle.
+- `ca_builtin_roots` (optional): `true` (default) or `false`. Set to `false` to
+  trust only the certificates from `ca_cert_file` and drop the built-in roots.
+  Valid only together with `ca_cert_file`.
+
+```ini
+replication.object.store=s3::bucket=${BUCKET_NAME};root=${DB_INSTANCE_NAME};region=${AWS_REGION};endpoint=https://minio.internal;ca_cert_file=/etc/ssl/private-ca.pem;
+```
+
+Both parameters are valid only for the HTTP-based backends (`s3`, `azblob`,
+`gcs`) and are rejected for `fs` (NFS). They belong to the object store
+connection string, so they work the same way in `backup.object.store`. The file
+is read and parsed at startup, so a missing or malformed PEM fails fast with an
+`InvalidObjectStoreConfigurationException`.
+
+:::caution
+
+- **Point it at the CA, not the server certificate.** `ca_cert_file` must hold
+  the CA certificate(s) that issued the store's certificate (the root plus any
+  intermediates), not the store's own server certificate. Startup validation
+  only checks that the PEM parses, so a server certificate passes validation but
+  then fails every request with a certificate-trust error.
+- **No `;` in the path.** The connection string is split on `;` with no escape,
+  so a certificate path must not contain a `;`. A parameter with no `=` (for
+  example a path truncated at a `;`) is now rejected at startup rather than
+  silently dropped.
+- **Data requests only.** The custom CA applies to object store data requests
+  (read, write, list, delete). Dynamic credential and token fetches (S3
+  IMDS/STS/assume-role and the GCS OAuth token endpoint) go through a separate
+  client that always trusts the built-in roots. Stores that authenticate with
+  static credentials (S3 `access_key_id` and `secret_access_key`, or Azure
+  `account_key`) make no such fetch and are unaffected. A `gcs` store reached
+  through a private or intercepting CA must therefore also be given a static
+  OAuth `token`, otherwise its token fetch fails the handshake at runtime even
+  though the configuration validates.
+
+:::
+
 ## 2. Configure the primary node
 
 Add to `server.conf`:

--- a/documentation/operations/backup.md
+++ b/documentation/operations/backup.md
@@ -52,7 +52,8 @@ Backup supports the following storage backends:
   sensitive to the underlying filesystem type.
 
 See [Configure object storage](/docs/high-availability/setup/#1-configure-object-storage)
-for connection string formats.
+for connection string formats. For a private, on-prem, or self-signed store,
+see [TLS with a private or self-signed CA](/docs/high-availability/setup/#tls-with-a-private-or-self-signed-ca).
 
 #### Permissions
 


### PR DESCRIPTION
## Summary

Documents the `ca_cert_file` and `ca_builtin_roots` object store
connection-string parameters introduced in questdb/questdb-enterprise#1043.
They let QuestDB trust a private, internal, or self-signed CA when connecting to
an `s3`, `azblob`, or `gcs` store over TLS (on-prem appliances, S3-compatible
stores behind an internal CA, or a TLS-intercepting proxy).

- **`high-availability/setup.md`**: new "TLS with a private or self-signed CA"
  subsection under "Configure object storage", the canonical reference. Covers
  the two parameters, an example, backend scope (`fs`/NFS rejected; also applies
  to `backup.object.store`), and the key caveats: point at the CA rather than
  the server certificate, no `;` in the path, and that dynamic credential and
  token fetches (S3 IMDS/STS, GCS OAuth) keep using the built-in roots.
- **`configuration/database-replication.md`**: pointer from the
  `replication.object.store` reference entry.
- **`operations/backup.md`**: pointer from the storage-backend prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
