### PR TITLE
Add QuestDB Enterprise releases to changelog and skill

### DIFF
--- a/.claude/skills/docs-changelog/SKILL.md
+++ b/.claude/skills/docs-changelog/SKILL.md
@@ -57,6 +57,38 @@ Rules:
 - Place "Releases" FIRST in each month (before New, Updated, etc.)
 - Omit if no releases that month
 
+#### Enterprise releases
+
+QuestDB Enterprise ships on its own version track (`3.x`) from a separate,
+private repository. Fetch its releases the same way:
+
+```bash
+gh api repos/questdb/questdb-enterprise/releases --jq '.[] | "\(.tag_name)|\(.published_at)"'
+```
+
+This repo is private. If the contributor's GitHub token has access the command
+returns releases; if not, it fails with a 404 or permission error. Treat any
+failure as "no Enterprise releases available" and skip the section silently. Do
+NOT fail the changelog over it.
+
+When the command succeeds, filter to releases within the period and render them
+under their own header, immediately after the OSS `Releases` section:
+
+```markdown
+### QuestDB Enterprise Releases
+
+- [3.3.1](https://questdb.com/release-notes/) - Released June 9, 2026
+- [3.3.0](https://questdb.com/release-notes/) - Released June 3, 2026
+```
+
+Rules:
+- Same format and link target as OSS releases (`https://questdb.com/release-notes/`);
+  both editions are listed on that page
+- One line per release, descending order (newest first)
+- Include the section ONLY when there is at least one Enterprise release in the
+  period (and the repo was accessible)
+- Place it directly after the `Releases` section, before `New`
+
 ### Step 4: Analyze each commit
 
 For each commit hash, check the diff:
@@ -90,16 +122,36 @@ git diff <hash>^..<hash> -- '*.md' '*.mdx'
 - Tutorial additions/updates
 - Corrected technical instructions
 
+#### Reconcile against the existing changelog
+
+Before including a change, check whether it is ALREADY covered anywhere in
+`changelog.mdx`, not just under the month you are currently writing. A commit's
+date and the month its entry was filed under do not always match (a commit
+dated June 4 may already be listed under May), so a check scoped to a single
+month produces false duplicates. Search the whole file for the function name,
+page path, or feature before deciding.
+
+- If the same change is already described, SKIP it. Do not restate it.
+- If the commit makes a genuinely NEW, changelog-worthy change to content that
+  was documented (and changelogged) earlier, DO report it. A follow-up that
+  adds a parameter, a new syntax form, a corrected behavior, or a new section
+  to an already-listed page is a legitimate new entry, not a duplicate.
+  Describe what changed this time, not the original addition.
+
+The same reconciliation applies to releases: do not re-list a release (OSS or
+Enterprise) that already appears in the changelog for its period.
+
 ### Step 5: Categorize changes
 
 Group into these categories, always in this exact order. Skip a category if
 there are no entries for it, but never reorder:
 
-1. **Releases** - QuestDB releases in the period (from Step 3)
-2. **New** - Brand new pages or major new sections (content that did not exist before)
-3. **Reference** - Individual functions, parameters, config properties, or syntax additions to existing reference pages
-4. **Guides** - Tutorials, how-tos, walkthroughs
-5. **Updated** - Significant updates to existing content (restructured pages, rewritten sections, new examples)
+1. **Releases** - QuestDB (OSS) releases in the period (from Step 3)
+2. **QuestDB Enterprise Releases** - Enterprise releases in the period (from Step 3), only when accessible and non-empty
+3. **New** - Brand new pages or major new sections (content that did not exist before)
+4. **Reference** - Individual functions, parameters, config properties, or syntax additions to existing reference pages
+5. **Guides** - Tutorials, how-tos, walkthroughs
+6. **Updated** - Significant updates to existing content (restructured pages, rewritten sections, new examples)
 
 ### Step 6: Generate the entry
 
@@ -111,6 +163,10 @@ Format as Docusaurus-compatible MDX, one `## Month YYYY` header per month:
 ### Releases
 
 - [9.4.0](https://questdb.com/release-notes/) - Released February 15, 2026
+
+### QuestDB Enterprise Releases
+
+- [3.2.2](https://questdb.com/release-notes/) - Released February 4, 2026
 
 ### New
 

--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -15,6 +15,11 @@ This page tracks significant updates to the QuestDB documentation.
 - [9.4.2](https://questdb.com/release-notes/) - Released June 9, 2026
 - [9.4.1](https://questdb.com/release-notes/) - Released June 3, 2026
 
+### QuestDB Enterprise Releases
+
+- [3.3.1](https://questdb.com/release-notes/) - Released June 9, 2026
+- [3.3.0](https://questdb.com/release-notes/) - Released June 3, 2026
+
 ### Reference
 
 - Documented the column wildcard with optional `EXCLUDE` list for column-level [`GRANT`](/docs/query/sql/acl/grant/#grant-on-all-columns-of-a-table) and [`REVOKE`](/docs/query/sql/acl/revoke/#revoke-from-all-columns-of-a-table) — `GRANT SELECT ON trades(*) TO user` grants every current column, and `EXCLUDE` omits specific ones
@@ -76,6 +81,10 @@ This page tracks significant updates to the QuestDB documentation.
 
 - [9.3.5](https://questdb.com/release-notes/) - Released April 13, 2026
 
+### QuestDB Enterprise Releases
+
+- [3.2.5](https://questdb.com/release-notes/) - Released April 13, 2026
+
 ### New
 
 - [Storage policy](/docs/concepts/storage-policy/) - Documentation for configuring storage policies
@@ -110,6 +119,11 @@ This page tracks significant updates to the QuestDB documentation.
 
 - [9.3.4](https://questdb.com/release-notes/) - Released March 26, 2026
 
+### QuestDB Enterprise Releases
+
+- [3.2.4](https://questdb.com/release-notes/) - Released March 26, 2026
+- [3.2.3](https://questdb.com/release-notes/) - Released March 3, 2026
+
 ### New
 
 - [Log returns](/docs/cookbook/sql/finance/log-returns/) and [gamma scalping signal](/docs/cookbook/sql/finance/gamma-scalping-signal/) cookbook recipes
@@ -135,6 +149,10 @@ This page tracks significant updates to the QuestDB documentation.
 ### Releases
 
 - [9.3.3](https://questdb.com/release-notes/) - Released February 25, 2026
+
+### QuestDB Enterprise Releases
+
+- [3.2.2](https://questdb.com/release-notes/) - Released February 4, 2026
 
 ### New
 
@@ -170,6 +188,11 @@ This page tracks significant updates to the QuestDB documentation.
 - [9.3.1](https://questdb.com/release-notes/) - Released January 14, 2026
 - [9.3.0](https://questdb.com/release-notes/) - Released January 9, 2026
 
+### QuestDB Enterprise Releases
+
+- [3.2.1](https://questdb.com/release-notes/) - Released January 29, 2026
+- [3.2.0](https://questdb.com/release-notes/) - Released January 19, 2026
+
 ### New
 
 - [Cookbook](/docs/cookbook/) - Collection of 40+ recipes for common SQL patterns, integrations, and operations
@@ -201,6 +224,11 @@ This page tracks significant updates to the QuestDB documentation.
 - [9.2.3](https://questdb.com/release-notes/) - Released December 18, 2025
 - [9.2.2](https://questdb.com/release-notes/) - Released December 1, 2025
 
+### QuestDB Enterprise Releases
+
+- [3.1.2](https://questdb.com/release-notes/) - Released December 18, 2025
+- [3.1.1](https://questdb.com/release-notes/) - Released December 1, 2025
+
 ### New
 
 - [Builtin profiler](/docs/troubleshooting/profiling/) - Documentation for QuestDB's built-in query profiler
@@ -223,6 +251,11 @@ This page tracks significant updates to the QuestDB documentation.
 - [9.2.1](https://questdb.com/release-notes/) - Released November 25, 2025
 - [9.2.0](https://questdb.com/release-notes/) - Released November 13, 2025
 - [9.1.1](https://questdb.com/release-notes/) - Released November 3, 2025
+
+### QuestDB Enterprise Releases
+
+- [3.1.0](https://questdb.com/release-notes/) - Released November 25, 2025
+- [3.0.5](https://questdb.com/release-notes/) - Released November 7, 2025
 
 ### New
 
@@ -247,6 +280,10 @@ This page tracks significant updates to the QuestDB documentation.
 
 - [9.1.0](https://questdb.com/release-notes/) - Released October 3, 2025
 
+### QuestDB Enterprise Releases
+
+- [3.0.4](https://questdb.com/release-notes/) - Released October 27, 2025
+
 ### New
 
 - [PGWire for C/C++](/docs/query/pgwire/c-and-cpp/) - Guide for C/C++ applications using PostgreSQL wire protocol
@@ -264,6 +301,10 @@ This page tracks significant updates to the QuestDB documentation.
 
 ## September 2025
 
+### QuestDB Enterprise Releases
+
+- [3.0.3](https://questdb.com/release-notes/) - Released September 15, 2025
+
 ### Updated
 
 - [Partitioning](/docs/concepts/partitions/) - Improved formatting and explanations
@@ -275,6 +316,11 @@ This page tracks significant updates to the QuestDB documentation.
 
 - [9.0.3](https://questdb.com/release-notes/) - Released August 29, 2025
 - [9.0.2](https://questdb.com/release-notes/) - Released August 15, 2025
+
+### QuestDB Enterprise Releases
+
+- [3.0.2](https://questdb.com/release-notes/) - Released August 29, 2025
+- [3.0.1](https://questdb.com/release-notes/) - Released August 15, 2025
 
 ### New
 
@@ -291,6 +337,10 @@ This page tracks significant updates to the QuestDB documentation.
 
 - [9.0.1](https://questdb.com/release-notes/) - Released July 23, 2025
 - [9.0.0](https://questdb.com/release-notes/) - Released July 11, 2025
+
+### QuestDB Enterprise Releases
+
+- [3.0.0](https://questdb.com/release-notes/) - Released July 23, 2025
 
 ### New
 


### PR DESCRIPTION
## Summary

- Extend the docs-changelog skill to fetch Enterprise releases from `questdb/questdb-enterprise` and render them under a **QuestDB Enterprise Releases** section after the OSS Releases section, with a graceful skip when the private repo is inaccessible.
- Add whole-changelog reconciliation guidance so already-recorded changes are not duplicated.
- Backfill the Enterprise Releases sections across every month from July 2025 to now (3.0.0 through 3.3.1).