### PR TITLE
SEO fixes — Ahrefs Site Audit (docs companion)

### DIFF
--- a/documentation/concepts/deep-dive/jit-compiler.md
+++ b/documentation/concepts/deep-dive/jit-compiler.md
@@ -14,7 +14,7 @@ do so, the JIT compiler emits machine code with a single function that may also
 use SIMD (vector) instructions.
 
 For details on the implementation, motivation, and internals of this feature,
-see our [article about SQL JIT compilation](/blog/2022/01/12/jit-sql-compiler).
+see our [article about SQL JIT compilation](/blog/2022/01/12/jit-sql-compiler/).
 This post describes our storage model, how we built a JIT compiler for SQL and
 our plans for improving it in future.
 

--- a/documentation/high-availability/overview.md
+++ b/documentation/high-availability/overview.md
@@ -67,7 +67,7 @@ WAL files when needed. Slower recovery, lower cost.
 | NFS filesystem | Supported |
 | HDFS | Planned |
 
-Need something else? [Contact us](/enterprise/contact).
+Need something else? [Contact us](/enterprise/contact/).
 
 ## Requirements
 

--- a/documentation/ingestion/clients/date-to-timestamp-conversion.md
+++ b/documentation/ingestion/clients/date-to-timestamp-conversion.md
@@ -1,5 +1,5 @@
 ---
-title: Date to Timestamp Conversion in Different Programming Languages
+title: Date-to-timestamp conversion by language
 sidebar_label: Date to Timestamp
 description: Python, Go, JAVA, JavaScript, C/C++, Rust, .Net, PHP, or Ruby.
 ---

--- a/documentation/ingestion/message-brokers/flink.md
+++ b/documentation/ingestion/message-brokers/flink.md
@@ -10,7 +10,7 @@ import InterpolateReleaseData from "../../../src/components/InterpolateReleaseDa
 import CodeBlock from "@theme/CodeBlock"
 
 [Apache Flink](https://flink.apache.org/) is a popular framework and
-[stream processing](/glossary/stream-processing) engine. QuestDB ships a
+[stream processing](/glossary/stream-processing/) engine. QuestDB ships a
 [QuestDB Flink Sink connector](https://github.com/questdb/flink-questdb-connector)
 for fast ingestion from Apache Flink into QuestDB. The connector implements the
 [Table API and SQL](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/dev/table/overview/)

--- a/documentation/ingestion/message-brokers/kafka.md
+++ b/documentation/ingestion/message-brokers/kafka.md
@@ -645,7 +645,7 @@ Use Debezium's `ExtractNewRecordState` transformation to extract the new record
 state. DELETE events are dropped by default.
 
 See the [Debezium sample project](https://github.com/questdb/kafka-questdb-connector/tree/main/kafka-questdb-connector-samples/stocks)
-and the blog post [Change Data Capture with QuestDB and Debezium](/blog/2023/01/03/change-data-capture-with-questdb-and-debezium).
+and the blog post [Change Data Capture with QuestDB and Debezium](/blog/2023/01/03/change-data-capture-with-questdb-and-debezium/).
 
 **Typical pattern:** Use a relational database for current state and QuestDB
 for change history. For example, PostgreSQL holds current stock prices while
@@ -692,5 +692,5 @@ key.converter.schemas.enable=false
 
 ## See also
 
-- [Change Data Capture with QuestDB and Debezium](/blog/2023/01/03/change-data-capture-with-questdb-and-debezium)
-- [Realtime crypto tracker with QuestDB Kafka Connector](/blog/realtime-crypto-tracker-with-questdb-kafka-connector)
+- [Change Data Capture with QuestDB and Debezium](/blog/2023/01/03/change-data-capture-with-questdb-and-debezium/)
+- [Realtime crypto tracker with QuestDB Kafka Connector](/blog/realtime-crypto-tracker-with-questdb-kafka-connector/)

--- a/documentation/ingestion/message-brokers/redpanda.md
+++ b/documentation/ingestion/message-brokers/redpanda.md
@@ -10,7 +10,7 @@ description:
 platform that uses C++ and Raft to replace Java and Zookeeper. Since it is Kafka
 compatible, it can be used with the
 [QuestDB Kafka connector](/docs/ingestion/message-brokers/kafka/#questdb-kafka-connect-connector),
-providing an alternative data [streaming](/glossary/stream-processing) option.
+providing an alternative data [streaming](/glossary/stream-processing/) option.
 
 This guide also covers [Redpanda Connect](#redpanda-connect), a stream processing
 tool that can be used to build data pipelines.

--- a/documentation/integrations/data-processing/spark.md
+++ b/documentation/integrations/data-processing/spark.md
@@ -14,7 +14,7 @@ High-level instructions for loading data from QuestDB to Spark and back.
 ## What is Spark?
 
 [Apache Spark](https://spark.apache.org/) is an analytics engine for large-scale
-data engineering and [stream processing](/glossary/stream-processing),
+data engineering and [stream processing](/glossary/stream-processing/),
 well-known in the big data landscape. It is suitable for executing data
 engineering, data science, and machine learning on single-node machines or
 clusters.

--- a/documentation/introduction.md
+++ b/documentation/introduction.md
@@ -1,5 +1,5 @@
 ---
-title: "QuestDB Documentation - SQL Time-Series Database Guides"
+title: "QuestDB Documentation: SQL time-series guides"
 sidebar_label: Introduction
 hide_title: true
 slug: /

--- a/documentation/query/functions/aggregation.md
+++ b/documentation/query/functions/aggregation.md
@@ -127,7 +127,7 @@ in this documentation often omit `GROUP BY` for brevity.
 
 `approx_count_distinct(column_name, precision)` - estimates the number of
 distinct non-`NULL` values in `IPv4`, `int`, or `long` columns using the
-[HyperLogLog](/glossary/HyperLogLog/) data structure, which provides an
+[HyperLogLog](/glossary/hyperloglog/) data structure, which provides an
 approximation rather than an exact count.
 
 The precision of HyperLogLog can be controlled via the optional `precision`

--- a/documentation/security/oidc.mdx
+++ b/documentation/security/oidc.mdx
@@ -793,7 +793,7 @@ The token manager is responsible for issuing access tokens.
 All token related settings should be configured in the token manager.
 
 <Screenshot
-  alt=""
+  alt="Enabling PKCE in the Active Directory OIDC token manager settings"
   src="images/guides/active-directory/5.webp"
   title="PKCE enabled"
   width={500}

--- a/documentation/tutorials/influxdb-migration.md
+++ b/documentation/tutorials/influxdb-migration.md
@@ -253,4 +253,4 @@ protocol, or compare QuestDB with Influx:
 - [ILP `server.conf` configuration](/docs/configuration/ingestion/)
 - [ILP API Overview](/docs/ingestion/ilp/overview/)
 - [Comparing TimescaleDB and QuestDB performance and architecture blog](/blog/timescaledb-vs-questdb-comparison/)
-- [Deep dive of QuestDB vs InfluxDB internals](/blog/2024/02/26/questdb-versus-influxdb/)
+- [Deep dive of QuestDB vs InfluxDB internals](/blog/influxdb-vs-questdb-comparison/)


### PR DESCRIPTION
Companion docs-side changes for the questdb.io SEO PR (questdb/questdb.io#2921), addressing the 2026-06-29 Ahrefs Site Audit on `/docs/*` pages.

## Changes (11 files)

**Page has links to redirect** — repoint internal links to their final 200 destination (no more 301 hop):
- Trailing-slash fixes: `concepts/deep-dive/jit-compiler.md`, `high-availability/overview.md` (`/enterprise/contact/`), `ingestion/message-brokers/{flink,redpanda,kafka}.md`, `integrations/data-processing/spark.md` (`/glossary/stream-processing/`, blog permalinks)
- `tutorials/influxdb-migration.md`: moved post → `/blog/influxdb-vs-questdb-comparison/`
- `query/functions/aggregation.md`: `HyperLogLog` → `/glossary/hyperloglog/` (casing)

**Title too long** — shorten to ≤60 chars so Google shows the full title:
- `ingestion/clients/date-to-timestamp-conversion.md`
- `introduction.md`

**Missing alt text**:
- `security/oidc.mdx` — add alt to the OIDC PKCE screenshot


**Tandem PR**: https://github.com/questdb/questdb.io/pull/2921

🤖 Generated with [Claude Code](https://claude.com/claude-code)
