### PR TITLE
feat: generate llms-full.txt with complete docs content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ plugins/*/compiled
 .netlify
 .cache-loader
 static/llms.txt
+static/llms-full.txt
 static/reference-full.md
 static/web-console/*.json
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "cross-env docusaurus start --port 3001",
-    "prebuild": "docusaurus clear && node ./scripts/generate-llms-files.js && node ./scripts/generate-reference-full.js && node ./scripts/generate-web-console-json.js",
+    "prebuild": "docusaurus clear && node ./scripts/generate-llms-files.js && node ./scripts/generate-llms-full.js && node ./scripts/generate-reference-full.js && node ./scripts/generate-web-console-json.js",
     "build": "cross-env NO_UPDATE_NOTIFIER=true USE_SIMPLE_CSS_MINIFIER=true PWA_SW_CUSTOM= docusaurus build",
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",

--- a/scripts/generate-llms-files.js
+++ b/scripts/generate-llms-files.js
@@ -4,6 +4,7 @@ const yaml = require('js-yaml')
 
 const sidebarConfig = require('../documentation/sidebars.js')
 const { generateUrl: buildDocUrl } = require('./lib/docs-urls')
+const { subtreeContainsDoc } = require('./lib/sidebar-utils')
 
 const processedFiles = new Map()
 
@@ -57,17 +58,6 @@ function generateUrl(docId, docPath) {
   // Extract frontmatter to check for custom slug
   const { slug } = extractFrontmatter(docPath)
   return buildDocUrl(docId, slug)
-}
-
-function subtreeContainsDoc(items, docId) {
-  if (!items) return false
-  return items.some(item =>
-    (typeof item === 'string' && item === docId) ||
-    (item.type === 'doc' && item.id === docId) ||
-    (item.type === 'category' &&
-      ((item.link && item.link.type === 'doc' && item.link.id === docId) ||
-        subtreeContainsDoc(item.items, docId)))
-  )
 }
 
 function processForLlmsTxt(items, indent = 0, isTopLevel = false) {

--- a/scripts/generate-llms-files.js
+++ b/scripts/generate-llms-files.js
@@ -3,7 +3,7 @@ const path = require('path')
 const yaml = require('js-yaml')
 
 const sidebarConfig = require('../documentation/sidebars.js')
-const BASE_URL = 'https://questdb.com/docs/'
+const { generateUrl: buildDocUrl } = require('./lib/docs-urls')
 
 const processedFiles = new Map()
 
@@ -53,43 +53,21 @@ function extractFrontmatter(filePath) {
   }
 }
 
-function normalizeUrl(url) {
-  const clean = url.endsWith("/") ? url.slice(0, -1) : url
-  return clean + ".md"
-}
-
 function generateUrl(docId, docPath) {
   // Extract frontmatter to check for custom slug
   const { slug } = extractFrontmatter(docPath)
+  return buildDocUrl(docId, slug)
+}
 
-  if (slug) {
-    let urlPath = slug
-
-    // Absolute slug (starts with /)
-    if (urlPath.startsWith('/')) {
-      urlPath = urlPath.substring(1)
-      if (urlPath === '') {
-        return BASE_URL + "index.md"
-      }
-      return normalizeUrl(BASE_URL + urlPath)
-    }
-
-    // Relative slug - resolve it relative to the document's directory
-    const docDir = path.dirname(docId)
-    if (docDir && docDir !== '.') {
-      urlPath = path.join(docDir, urlPath)
-    }
-
-    return normalizeUrl(BASE_URL + urlPath)
-  }
-
-  // Default behavior: use docId
-  if (docId === 'introduction') {
-    return BASE_URL + "index.md"
-  }
-  // Strip /index suffix to match raw-markdown plugin output (e.g. cookbook/index -> cookbook.md)
-  let urlDocId = docId.endsWith('/index') ? docId.slice(0, -'/index'.length) : docId
-  return normalizeUrl(BASE_URL + urlDocId)
+function subtreeContainsDoc(items, docId) {
+  if (!items) return false
+  return items.some(item =>
+    (typeof item === 'string' && item === docId) ||
+    (item.type === 'doc' && item.id === docId) ||
+    (item.type === 'category' &&
+      ((item.link && item.link.type === 'doc' && item.link.id === docId) ||
+        subtreeContainsDoc(item.items, docId)))
+  )
 }
 
 function processForLlmsTxt(items, indent = 0, isTopLevel = false) {
@@ -123,13 +101,25 @@ function processForLlmsTxt(items, indent = 0, isTopLevel = false) {
       result += '\n'
       
     } else if (item.type === 'category') {
+      // A category's own link page (link: {type: 'doc'}) is a real doc too,
+      // unless the same doc is already listed among the category's items
+      const linkDoc = item.link && item.link.type === 'doc' && item.link.id &&
+        !subtreeContainsDoc(item.items, item.link.id)
+        ? [{ type: 'doc', id: item.link.id }]
+        : []
       if (isTopLevel) {
         result += `\n## ${item.label}\n`
+        if (linkDoc.length > 0) {
+          result += processForLlmsTxt(linkDoc, 0, false)
+        }
         if (item.items && item.items.length > 0) {
           result += processForLlmsTxt(item.items, 0, false)
         }
       } else {
         result += `${indentStr}${item.label}\n`
+        if (linkDoc.length > 0) {
+          result += processForLlmsTxt(linkDoc, indent + 1, false)
+        }
         if (item.items && item.items.length > 0) {
           result += processForLlmsTxt(item.items, indent + 1, false)
         }

--- a/scripts/generate-llms-full.js
+++ b/scripts/generate-llms-full.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const yaml = require('js-yaml')
+const matter = require('gray-matter')
 const {
   convertAllComponents,
   bumpHeadings,
@@ -8,13 +8,14 @@ const {
   removeImports,
   processPartialImports,
 } = require('../plugins/raw-markdown/convert-components')
+const remoteRepoExamplePlugin = require('../plugins/remote-repo-example/index')
 
 const sidebarConfig = require('../documentation/sidebars.js')
+const { BASE_URL, generateUrl } = require('./lib/docs-urls')
 
 const ROOT_DIR = path.resolve(__dirname, '..')
 const DOCS_DIR = path.join(ROOT_DIR, 'documentation')
 const OUTPUT_DIR = path.join(ROOT_DIR, 'static')
-const BASE_URL = 'https://questdb.com/docs/'
 
 function readDocFile(docId) {
   const mdPath = path.join(DOCS_DIR, docId + '.md')
@@ -43,9 +44,7 @@ function loadPartial(partialPath, currentFileDir) {
 
   if (fs.existsSync(absolutePath)) {
     const partialRaw = fs.readFileSync(absolutePath, 'utf8')
-    const frontmatterRegex = /^---\s*\n[\s\S]*?\n---\s*\n([\s\S]*)$/
-    const match = partialRaw.match(frontmatterRegex)
-    const content = match ? match[1] : partialRaw
+    const { content } = matter(partialRaw)
     partialCache.set(absolutePath, content)
     return content
   }
@@ -54,64 +53,23 @@ function loadPartial(partialPath, currentFileDir) {
   return `<!-- Partial not found: ${partialPath} -->`
 }
 
-function normalizeUrl(url) {
-  const clean = url.endsWith('/') ? url.slice(0, -1) : url
-  return clean + '.md'
-}
-
-function generateUrl(docId, slug) {
-  if (slug) {
-    let urlPath = slug
-
-    // Absolute slug (starts with /)
-    if (urlPath.startsWith('/')) {
-      urlPath = urlPath.substring(1)
-      if (urlPath === '') {
-        return BASE_URL + 'index.md'
-      }
-      return normalizeUrl(BASE_URL + urlPath)
-    }
-
-    // Relative slug - resolve it relative to the document's directory
-    const docDir = path.dirname(docId)
-    if (docDir && docDir !== '.') {
-      urlPath = path.join(docDir, urlPath)
-    }
-
-    return normalizeUrl(BASE_URL + urlPath)
-  }
-
-  if (docId === 'introduction') {
-    return BASE_URL + 'index.md'
-  }
-  // Strip /index suffix to match raw-markdown plugin output (e.g. cookbook/index -> cookbook.md)
-  const urlDocId = docId.endsWith('/index') ? docId.slice(0, -'/index'.length) : docId
-  return normalizeUrl(BASE_URL + urlDocId)
-}
-
-async function renderDoc(docId) {
+async function renderDoc(docId, repoExamples) {
   const doc = readDocFile(docId)
   if (!doc) return ''
 
-  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/
-  const match = doc.raw.match(frontmatterRegex)
-
-  let frontmatter = {}
-  let mainContent = doc.raw
-
-  if (match) {
-    try {
-      frontmatter = yaml.load(match[1]) || {}
-    } catch (_) {}
-    mainContent = match[2]
-  }
+  const { data: frontmatter, content: mainContent } = matter(doc.raw)
 
   // Process partial component imports
   const relativeDir = path.relative(DOCS_DIR, path.dirname(doc.filePath))
   let processedContent = processPartialImports(mainContent, loadPartial, relativeDir)
 
   // Convert MDX components to markdown
-  processedContent = await convertAllComponents(processedContent, path.dirname(doc.filePath), DOCS_DIR)
+  processedContent = await convertAllComponents(
+    processedContent,
+    path.dirname(doc.filePath),
+    DOCS_DIR,
+    repoExamples,
+  )
 
   processedContent = removeImports(processedContent)
   processedContent = normalizeNewLines(processedContent)
@@ -133,6 +91,7 @@ async function renderDoc(docId) {
 
 // Walk the sidebar in order, collecting doc ids grouped by top-level category.
 // Loose top-level docs fall under "Getting Started", matching llms.txt.
+// A category's own `link: {type: 'doc'}` page is included before its items.
 function collectSections(items) {
   const sections = []
   let current = { label: 'Getting Started', docIds: [] }
@@ -143,8 +102,13 @@ function collectSections(items) {
         into.push(item)
       } else if (item.type === 'doc') {
         into.push(item.id)
-      } else if (item.type === 'category' && item.items) {
-        collectDocIds(item.items, into)
+      } else if (item.type === 'category') {
+        if (item.link && item.link.type === 'doc' && item.link.id) {
+          into.push(item.link.id)
+        }
+        if (item.items) {
+          collectDocIds(item.items, into)
+        }
       }
       // item.type === 'link' is external; skip
     }
@@ -160,6 +124,9 @@ function collectSections(items) {
         sections.push(current)
       }
       current = { label: item.label, docIds: [] }
+      if (item.link && item.link.type === 'doc' && item.link.id) {
+        current.docIds.push(item.link.id)
+      }
       if (item.items) {
         collectDocIds(item.items, current.docIds)
       }
@@ -176,6 +143,10 @@ function collectSections(items) {
 async function generateLlmsFull() {
   console.log('Generating llms-full.txt from QuestDB documentation...')
 
+  // Same remote example data the raw-markdown plugin receives at build time,
+  // so <RemoteRepoExample /> renders real code instead of its fallback
+  const repoExamples = await remoteRepoExamplePlugin().loadContent()
+
   const sections = collectSections(sidebarConfig.docs)
 
   let output = `# QuestDB Documentation — Full Content
@@ -186,12 +157,24 @@ markdown source.
 
 `
 
+  // Docs can appear in several sidebar positions; render each only once
+  const renderedDocIds = new Set()
   let docCount = 0
+  let duplicateCount = 0
+
   for (const section of sections) {
     output += `# ${section.label}\n\n`
     for (const docId of section.docIds) {
-      output += await renderDoc(docId)
-      docCount++
+      if (renderedDocIds.has(docId)) {
+        duplicateCount++
+        continue
+      }
+      renderedDocIds.add(docId)
+      const rendered = await renderDoc(docId, repoExamples)
+      if (rendered) {
+        output += rendered
+        docCount++
+      }
     }
   }
 
@@ -205,7 +188,7 @@ markdown source.
   const sizeMB = (Buffer.byteLength(output, 'utf8') / 1024 / 1024).toFixed(2)
   console.log('✅ llms-full.txt generated successfully!')
   console.log(`   - Path: ${targetPath}`)
-  console.log(`   - Docs: ${docCount}`)
+  console.log(`   - Docs: ${docCount} (${duplicateCount} duplicate sidebar entries skipped)`)
   console.log(`   - Size: ${sizeMB} MB`)
 }
 

--- a/scripts/generate-llms-full.js
+++ b/scripts/generate-llms-full.js
@@ -12,6 +12,7 @@ const remoteRepoExamplePlugin = require('../plugins/remote-repo-example/index')
 
 const sidebarConfig = require('../documentation/sidebars.js')
 const { BASE_URL, generateUrl } = require('./lib/docs-urls')
+const { subtreeContainsDoc } = require('./lib/sidebar-utils')
 
 const ROOT_DIR = path.resolve(__dirname, '..')
 const DOCS_DIR = path.join(ROOT_DIR, 'documentation')
@@ -74,8 +75,10 @@ async function renderDoc(docId, repoExamples) {
   processedContent = removeImports(processedContent)
   processedContent = normalizeNewLines(processedContent)
 
-  // Body headings H2 -> H3 etc. so the manually emitted H2 title stays the top of each doc
-  processedContent = bumpHeadings(processedContent, 1)
+  // Bump body headings by 2 (H1 -> H3, H2 -> H4, …) so nothing in a doc body
+  // can collide with the H1 section headers or the H2 per-doc title below —
+  // some docs (introduction, changelog) legitimately contain body H1s
+  processedContent = bumpHeadings(processedContent, 2)
 
   const title = frontmatter.title || docId
   const url = generateUrl(docId, frontmatter.slug || null)
@@ -89,12 +92,32 @@ async function renderDoc(docId, repoExamples) {
   return out
 }
 
-// Walk the sidebar in order, collecting doc ids grouped by top-level category.
-// Loose top-level docs fall under "Getting Started", matching llms.txt.
-// A category's own `link: {type: 'doc'}` page is included before its items.
+function docTitle(docId) {
+  const doc = readDocFile(docId)
+  if (!doc) return docId
+  const { data } = matter(doc.raw)
+  return data.title || docId
+}
+
+// Walk the sidebar in order, collecting doc ids grouped into sections.
+// Top-level categories become sections labeled by the category. Loose
+// top-level docs before the first category form an "Overview" section;
+// loose docs appearing after a category (e.g. changelog) each get their own
+// section labeled by the doc's title, so no doc is misattributed to a
+// neighboring category. A category's own `link: {type: 'doc'}` page is
+// included before its items unless the items already list it — the same
+// rule (and therefore the same order) as the llms.txt generator.
 function collectSections(items) {
   const sections = []
-  let current = { label: 'Getting Started', docIds: [] }
+  const leading = { label: 'Overview', docIds: [] }
+  let seenCategory = false
+
+  function categoryLinkDocIds(item) {
+    return item.link && item.link.type === 'doc' && item.link.id &&
+      !subtreeContainsDoc(item.items, item.link.id)
+      ? [item.link.id]
+      : []
+  }
 
   function collectDocIds(subItems, into) {
     for (const item of subItems) {
@@ -103,9 +126,7 @@ function collectSections(items) {
       } else if (item.type === 'doc') {
         into.push(item.id)
       } else if (item.type === 'category') {
-        if (item.link && item.link.type === 'doc' && item.link.id) {
-          into.push(item.link.id)
-        }
+        into.push(...categoryLinkDocIds(item))
         if (item.items) {
           collectDocIds(item.items, into)
         }
@@ -115,37 +136,55 @@ function collectSections(items) {
   }
 
   for (const item of items) {
-    if (typeof item === 'string') {
-      current.docIds.push(item)
-    } else if (item.type === 'doc') {
-      current.docIds.push(item.id)
+    if (typeof item === 'string' || item.type === 'doc') {
+      const docId = typeof item === 'string' ? item : item.id
+      if (seenCategory) {
+        sections.push({ label: docTitle(docId), docIds: [docId] })
+      } else {
+        leading.docIds.push(docId)
+      }
     } else if (item.type === 'category') {
-      if (current.docIds.length > 0) {
-        sections.push(current)
+      if (!seenCategory && leading.docIds.length > 0) {
+        sections.push(leading)
       }
-      current = { label: item.label, docIds: [] }
-      if (item.link && item.link.type === 'doc' && item.link.id) {
-        current.docIds.push(item.link.id)
-      }
+      seenCategory = true
+      const section = { label: item.label, docIds: [] }
+      section.docIds.push(...categoryLinkDocIds(item))
       if (item.items) {
-        collectDocIds(item.items, current.docIds)
+        collectDocIds(item.items, section.docIds)
       }
+      sections.push(section)
     }
   }
 
-  if (current.docIds.length > 0) {
-    sections.push(current)
+  if (!seenCategory && leading.docIds.length > 0) {
+    sections.push(leading)
   }
 
   return sections
 }
 
+// Same remote example data the raw-markdown plugin receives at build time,
+// so <RemoteRepoExample /> renders real code instead of its fallback.
+// Never fails the build: this data is only used for llms-full.txt, so on
+// persistent fetch errors we degrade to placeholder examples for one build
+// rather than blocking the whole docs deploy on a GitHub flake.
+async function loadRepoExamples() {
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      return await remoteRepoExamplePlugin().loadContent()
+    } catch (error) {
+      console.warn(`[generate-llms-full] Warning: could not load remote repo examples (attempt ${attempt}/2): ${error.message}`)
+    }
+  }
+  console.warn('[generate-llms-full] Proceeding without remote examples; <RemoteRepoExample /> blocks will render placeholders until the next successful build.')
+  return {}
+}
+
 async function generateLlmsFull() {
   console.log('Generating llms-full.txt from QuestDB documentation...')
 
-  // Same remote example data the raw-markdown plugin receives at build time,
-  // so <RemoteRepoExample /> renders real code instead of its fallback
-  const repoExamples = await remoteRepoExamplePlugin().loadContent()
+  const repoExamples = await loadRepoExamples()
 
   const sections = collectSections(sidebarConfig.docs)
 
@@ -163,7 +202,7 @@ markdown source.
   let duplicateCount = 0
 
   for (const section of sections) {
-    output += `# ${section.label}\n\n`
+    let body = ''
     for (const docId of section.docIds) {
       if (renderedDocIds.has(docId)) {
         duplicateCount++
@@ -172,9 +211,13 @@ markdown source.
       renderedDocIds.add(docId)
       const rendered = await renderDoc(docId, repoExamples)
       if (rendered) {
-        output += rendered
+        body += rendered
         docCount++
       }
+    }
+    // Skip the header if every doc in this section was a duplicate or missing
+    if (body) {
+      output += `# ${section.label}\n\n` + body
     }
   }
 

--- a/scripts/generate-llms-full.js
+++ b/scripts/generate-llms-full.js
@@ -1,0 +1,215 @@
+const fs = require('fs')
+const path = require('path')
+const yaml = require('js-yaml')
+const {
+  convertAllComponents,
+  bumpHeadings,
+  normalizeNewLines,
+  removeImports,
+  processPartialImports,
+} = require('../plugins/raw-markdown/convert-components')
+
+const sidebarConfig = require('../documentation/sidebars.js')
+
+const ROOT_DIR = path.resolve(__dirname, '..')
+const DOCS_DIR = path.join(ROOT_DIR, 'documentation')
+const OUTPUT_DIR = path.join(ROOT_DIR, 'static')
+const BASE_URL = 'https://questdb.com/docs/'
+
+function readDocFile(docId) {
+  const mdPath = path.join(DOCS_DIR, docId + '.md')
+  if (fs.existsSync(mdPath)) {
+    return { raw: fs.readFileSync(mdPath, 'utf8'), filePath: mdPath }
+  }
+  const mdxPath = path.join(DOCS_DIR, docId + '.mdx')
+  if (fs.existsSync(mdxPath)) {
+    return { raw: fs.readFileSync(mdxPath, 'utf8'), filePath: mdxPath }
+  }
+  console.warn(`[generate-llms-full] Warning: File not found: ${mdPath} or ${mdxPath}`)
+  return null
+}
+
+// Partial cache shared across all files
+const partialCache = new Map()
+
+function loadPartial(partialPath, currentFileDir) {
+  // Unescape markdown escaped characters (like \_ -> _)
+  const unescapedPath = partialPath.replace(/\\_/g, '_')
+  const absolutePath = path.resolve(path.join(DOCS_DIR, currentFileDir), unescapedPath)
+
+  if (partialCache.has(absolutePath)) {
+    return partialCache.get(absolutePath)
+  }
+
+  if (fs.existsSync(absolutePath)) {
+    const partialRaw = fs.readFileSync(absolutePath, 'utf8')
+    const frontmatterRegex = /^---\s*\n[\s\S]*?\n---\s*\n([\s\S]*)$/
+    const match = partialRaw.match(frontmatterRegex)
+    const content = match ? match[1] : partialRaw
+    partialCache.set(absolutePath, content)
+    return content
+  }
+
+  console.warn(`[generate-llms-full] Warning: Partial not found: ${absolutePath}`)
+  return `<!-- Partial not found: ${partialPath} -->`
+}
+
+function normalizeUrl(url) {
+  const clean = url.endsWith('/') ? url.slice(0, -1) : url
+  return clean + '.md'
+}
+
+function generateUrl(docId, slug) {
+  if (slug) {
+    let urlPath = slug
+
+    // Absolute slug (starts with /)
+    if (urlPath.startsWith('/')) {
+      urlPath = urlPath.substring(1)
+      if (urlPath === '') {
+        return BASE_URL + 'index.md'
+      }
+      return normalizeUrl(BASE_URL + urlPath)
+    }
+
+    // Relative slug - resolve it relative to the document's directory
+    const docDir = path.dirname(docId)
+    if (docDir && docDir !== '.') {
+      urlPath = path.join(docDir, urlPath)
+    }
+
+    return normalizeUrl(BASE_URL + urlPath)
+  }
+
+  if (docId === 'introduction') {
+    return BASE_URL + 'index.md'
+  }
+  // Strip /index suffix to match raw-markdown plugin output (e.g. cookbook/index -> cookbook.md)
+  const urlDocId = docId.endsWith('/index') ? docId.slice(0, -'/index'.length) : docId
+  return normalizeUrl(BASE_URL + urlDocId)
+}
+
+async function renderDoc(docId) {
+  const doc = readDocFile(docId)
+  if (!doc) return ''
+
+  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/
+  const match = doc.raw.match(frontmatterRegex)
+
+  let frontmatter = {}
+  let mainContent = doc.raw
+
+  if (match) {
+    try {
+      frontmatter = yaml.load(match[1]) || {}
+    } catch (_) {}
+    mainContent = match[2]
+  }
+
+  // Process partial component imports
+  const relativeDir = path.relative(DOCS_DIR, path.dirname(doc.filePath))
+  let processedContent = processPartialImports(mainContent, loadPartial, relativeDir)
+
+  // Convert MDX components to markdown
+  processedContent = await convertAllComponents(processedContent, path.dirname(doc.filePath), DOCS_DIR)
+
+  processedContent = removeImports(processedContent)
+  processedContent = normalizeNewLines(processedContent)
+
+  // Body headings H2 -> H3 etc. so the manually emitted H2 title stays the top of each doc
+  processedContent = bumpHeadings(processedContent, 1)
+
+  const title = frontmatter.title || docId
+  const url = generateUrl(docId, frontmatter.slug || null)
+
+  let out = `## ${title}\n\n`
+  out += `Source: ${url}\n\n`
+  if (frontmatter.description) {
+    out += `${frontmatter.description}\n\n`
+  }
+  out += processedContent.trim() + '\n\n'
+  return out
+}
+
+// Walk the sidebar in order, collecting doc ids grouped by top-level category.
+// Loose top-level docs fall under "Getting Started", matching llms.txt.
+function collectSections(items) {
+  const sections = []
+  let current = { label: 'Getting Started', docIds: [] }
+
+  function collectDocIds(subItems, into) {
+    for (const item of subItems) {
+      if (typeof item === 'string') {
+        into.push(item)
+      } else if (item.type === 'doc') {
+        into.push(item.id)
+      } else if (item.type === 'category' && item.items) {
+        collectDocIds(item.items, into)
+      }
+      // item.type === 'link' is external; skip
+    }
+  }
+
+  for (const item of items) {
+    if (typeof item === 'string') {
+      current.docIds.push(item)
+    } else if (item.type === 'doc') {
+      current.docIds.push(item.id)
+    } else if (item.type === 'category') {
+      if (current.docIds.length > 0) {
+        sections.push(current)
+      }
+      current = { label: item.label, docIds: [] }
+      if (item.items) {
+        collectDocIds(item.items, current.docIds)
+      }
+    }
+  }
+
+  if (current.docIds.length > 0) {
+    sections.push(current)
+  }
+
+  return sections
+}
+
+async function generateLlmsFull() {
+  console.log('Generating llms-full.txt from QuestDB documentation...')
+
+  const sections = collectSections(sidebarConfig.docs)
+
+  let output = `# QuestDB Documentation — Full Content
+
+Complete text of the QuestDB documentation as a single document, in the same
+order as the index at ${BASE_URL}llms.txt. Each entry links its canonical
+markdown source.
+
+`
+
+  let docCount = 0
+  for (const section of sections) {
+    output += `# ${section.label}\n\n`
+    for (const docId of section.docIds) {
+      output += await renderDoc(docId)
+      docCount++
+    }
+  }
+
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true })
+  }
+
+  const targetPath = path.join(OUTPUT_DIR, 'llms-full.txt')
+  fs.writeFileSync(targetPath, output)
+
+  const sizeMB = (Buffer.byteLength(output, 'utf8') / 1024 / 1024).toFixed(2)
+  console.log('✅ llms-full.txt generated successfully!')
+  console.log(`   - Path: ${targetPath}`)
+  console.log(`   - Docs: ${docCount}`)
+  console.log(`   - Size: ${sizeMB} MB`)
+}
+
+generateLlmsFull().catch(error => {
+  console.error('Error generating llms-full.txt:', error)
+  process.exitCode = 1
+})

--- a/scripts/lib/docs-urls.js
+++ b/scripts/lib/docs-urls.js
@@ -21,11 +21,20 @@ function generateUrl(docId, slug) {
       urlPath = path.join(fileDir, urlPath)
     }
   } else {
+    // Safety net: introduction carries `slug: /`; if slug extraction ever
+    // fails (parse error, unreadable file) fall back to the URL the plugin
+    // publishes for it rather than emitting a dead introduction.md link.
+    if (docId === 'introduction') {
+      return BASE_URL + 'index.md'
+    }
     urlPath = docId
     if (urlPath.endsWith('/index')) {
       urlPath = urlPath.replace(/\/index$/, '')
     }
   }
+  // Note: a trailing '/' in a slug is deliberately NOT stripped — the
+  // raw-markdown plugin writes `<slug>.md` verbatim, so stripping here
+  // would link a path the plugin never publishes.
 
   if (urlPath === '' || urlPath === '.') {
     return BASE_URL + 'index.md'

--- a/scripts/lib/docs-urls.js
+++ b/scripts/lib/docs-urls.js
@@ -1,0 +1,36 @@
+const path = require('path')
+
+const BASE_URL = 'https://questdb.com/docs/'
+
+// Canonical raw-markdown URL for a doc, shared by the llms.txt and
+// llms-full.txt generators. Mirrors plugins/raw-markdown/index.js exactly —
+// that plugin decides where the .md files are actually written, so any
+// divergence here produces dead Source links.
+function generateUrl(docId, slug) {
+  let urlPath
+
+  if (slug) {
+    urlPath = slug
+    if (urlPath.startsWith('/')) {
+      urlPath = urlPath.substring(1)
+    }
+    // Only prepend the doc's directory if the slug doesn't already include
+    // path segments (same rule as the raw-markdown plugin)
+    const fileDir = path.dirname(docId)
+    if (!urlPath.includes('/') && fileDir !== '.') {
+      urlPath = path.join(fileDir, urlPath)
+    }
+  } else {
+    urlPath = docId
+    if (urlPath.endsWith('/index')) {
+      urlPath = urlPath.replace(/\/index$/, '')
+    }
+  }
+
+  if (urlPath === '' || urlPath === '.') {
+    return BASE_URL + 'index.md'
+  }
+  return BASE_URL + urlPath + '.md'
+}
+
+module.exports = { BASE_URL, generateUrl }

--- a/scripts/lib/sidebar-utils.js
+++ b/scripts/lib/sidebar-utils.js
@@ -1,0 +1,16 @@
+// Shared sidebar helpers for the llms.txt / llms-full.txt generators.
+
+// True if docId appears anywhere in the given sidebar items subtree
+// (as a string entry, a doc entry, or a category's own link doc).
+function subtreeContainsDoc(items, docId) {
+  if (!items) return false
+  return items.some(item =>
+    (typeof item === 'string' && item === docId) ||
+    (item.type === 'doc' && item.id === docId) ||
+    (item.type === 'category' &&
+      ((item.link && item.link.type === 'doc' && item.link.id === docId) ||
+        subtreeContainsDoc(item.items, docId)))
+  )
+}
+
+module.exports = { subtreeContainsDoc }


### PR DESCRIPTION
## What
Add `scripts/generate-llms-full.js`, which generates `static/llms-full.txt` — the complete text of all documentation as a single file, served at `https://questdb.com/docs/llms-full.txt`.

## Why
The website's `llms.txt` (questdb.io repo) has long advertised a full docs corpus at `/docs/llms-full.txt`, but no such file was ever generated — the URL **404s**. questdb/questdb.io#2923 fixes the links on its side and auto-detects this file at build time, so the two PRs can merge in any order.

## How
- Walks `documentation/sidebars.js` in the same order as the `llms.txt` generator. Top-level categories become `#` sections; loose docs before the first category form an *Overview* section; loose docs after a category (changelog) get their own title-labeled section. Category `link: {type: 'doc'}` pages are included exactly where `llms.txt` lists them (shared `subtreeContainsDoc` gate). Docs listed in several sidebar positions render once.
- Each doc renders through the existing `plugins/raw-markdown/convert-components` pipeline with the `remote-repo-example` plugin's data, so `<RemoteRepoExample />` shows real code and output matches the per-page `.md` endpoints. Doc entries: `##` title + `Source:` canonical markdown URL + body with headings bumped by 2 (some docs carry body H1s — bump-by-1 would collide with the doc-delimiter level).
- **New `scripts/lib/docs-urls.js`** (canonical URLs, mirrors the raw-markdown plugin exactly, incl. an introduction→index.md safety net) and **`scripts/lib/sidebar-utils.js`** — both shared by the two generators.
- **Build resilience:** remote example data is only needed for llms-full.txt, so fetch failures retry once then degrade to placeholder examples for that build — a GitHub flake can never fail the docs deploy.
- Wired into `prebuild`, gitignored like `llms.txt` / `reference-full.md`. Frontmatter via `gray-matter` (existing dep).

## Review history
Two high-effort multi-agent review rounds; every confirmed finding fixed:
- **R1:** category-link docs dropped · RemoteRepoExample placeholders · duplicate doc bodies · URL-logic duplication/divergence · hand-rolled frontmatter regex.
- **R2:** phantom doc boundaries from body H1s · duplicate/mislabeled sections (two "Getting Started", changelog under Troubleshooting) · prebuild hard-failing on transient GitHub errors · introduction URL fallback · cross-generator link-doc ordering · bare headers for fully-deduped sections.

**Known accepted trade-offs** (noted, deliberately out of scope): the MDX→md conversion runs at prebuild *and* in the plugin's postBuild (as `generate-reference-full.js` already does); the render pipeline and URL logic are shared between the two generator scripts but the plugin itself doesn't consume the shared modules yet — consolidating generation into the plugin's postBuild is the right future cleanup but means touching the code path that produces every production `.md` page.

## Verified locally (fence-aware where relevant)
- **352 real H2 doc headers == 352 `Source:` lines** — every doc boundary is real, no phantoms.
- 15 content sections, exactly matching the sidebar: one *Getting Started*, *Overview* leading, *Documentation changelog* standalone. No empty sections.
- `cookbook/sql/finance.md` present; `vpin.md` exactly once; **zero** "Example not found" placeholders (real Java/Python/… example code verified).
- `llms.txt`: URL set = production + exactly the one previously-missing category-link doc; byte-identical before/after the shared-module refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)