### PR TITLE
Add jdk.internal.vm export to systemd example

### DIFF
--- a/documentation/deployment/systemd.md
+++ b/documentation/deployment/systemd.md
@@ -83,6 +83,7 @@ ExecStart=/usr/lib/jvm/java-25-openjdk-amd64/bin/java \
 -Dcontainerized=false \
 -ea -Dnoebug \
 --add-exports java.base/jdk.internal.math=io.questdb \
+--add-exports java.base/jdk.internal.vm=io.questdb \
 -p /home/[USER_NAME]/bin/questdb.jar \
 -m io.questdb/io.questdb.ServerMain \
 -d /home/[USER_NAME]/var/lib/questdb
@@ -100,6 +101,31 @@ SyslogIdentifier=questdb
 [Install]
 WantedBy=multi-user.target
 ```
+
+For QuestDB Enterprise, launch the enterprise module
+(`com.questdb/com.questdb.EntServerMain`) and target both `io.questdb` and
+`com.questdb` on the module flags. The corresponding `ExecStart` is:
+
+```shell
+ExecStart=/home/[USER_NAME]/questdb-enterprise/bin/java \
+-XX:+UnlockExperimentalVMOptions \
+-XX:+AlwaysPreTouch \
+-XX:+UseParallelGC \
+-ea -Dnoebug \
+--sun-misc-unsafe-memory-access=allow \
+--enable-native-access=io.questdb,com.questdb \
+--add-opens=java.base/java.lang=io.questdb,com.questdb \
+--add-opens=java.base/java.lang.reflect=io.questdb,com.questdb \
+--add-opens=java.base/java.nio=io.questdb,com.questdb \
+--add-opens=java.base/java.time.zone=io.questdb,com.questdb \
+--add-exports=java.base/jdk.internal.vm=io.questdb,com.questdb \
+-m com.questdb/com.questdb.EntServerMain \
+-d /home/[USER_NAME]/var/lib/questdb
+```
+
+The Enterprise package is a self-contained runtime image: the `io.questdb` and
+`com.questdb` modules are built into `bin/java`, so no `--module-path` / `-p` is
+required.
 
 `LimitNOFILE=1048576` raises the open-files limit above systemd's default of
 `524288`, which is below what QuestDB recommends. The kernel `vm.max_map_count`


### PR DESCRIPTION
## Problem

The `ExecStart` example on the systemd deployment page predates the Java 25
continuation feature and is missing one JVM flag:

```
--add-exports java.base/jdk.internal.vm=io.questdb
```

QuestDB **9.4.4** and QuestDB Enterprise **3.3.3** use Java 25 continuations in
the worker pool (`io.questdb.mp.continuation.WorkerContinuation`, whose static
initializer touches `jdk.internal.vm.ContinuationScope`). Without the export the
server fails at startup on every worker thread with:

```
NoClassDefFoundError: Could not initialize class io.questdb.mp.continuation.WorkerContinuation
Caused by: IllegalAccessError: class io.questdb.mp.continuation.WorkerContinuation
  cannot access class jdk.internal.vm.ContinuationScope ... because module
  java.base does not export jdk.internal.vm to module io.questdb
```

An Enterprise customer following this page hit exactly this after upgrading to
3.3.3. The bundled `bin/questdb.sh`, the Docker image, and the AWS AMI unit all
already pass this flag; only this hand-rolled systemd example was stale.

## Change

- Add `--add-exports java.base/jdk.internal.vm=io.questdb` to the example. The
  flag is a no-op on versions that do not use it, so it is safe on all releases.
- Document the QuestDB Enterprise variant: `com.questdb/com.questdb.EntServerMain`
  and adding `com.questdb` alongside `io.questdb` on the `--add-exports` /
  `--add-opens` flags.

## Notes

- OSS release status: the continuation commit (#7031, 2026-06-16) landed after
  tag `9.4.3` (2026-06-15) and is not in any released OSS tag yet; it will first
  ship in `9.4.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)