### PR TITLE
docs: cover TTL on materialized views in the TTL concept page

### DIFF
--- a/documentation/concepts/ttl.md
+++ b/documentation/concepts/ttl.md
@@ -71,6 +71,25 @@ ALTER TABLE trades SET TTL 2w;
 For full syntax, see
 [ALTER TABLE SET TTL](/docs/query/sql/alter-table-set-ttl/).
 
+### On materialized views
+
+Materialized views support TTL as well, both at creation and afterward:
+
+```questdb-sql
+-- At view creation
+CREATE MATERIALIZED VIEW trades_hourly AS (
+  SELECT timestamp, symbol, avg(price) AS avg_price FROM trades SAMPLE BY 1h
+) PARTITION BY DAY TTL 7 DAYS;
+
+-- On an existing view
+ALTER MATERIALIZED VIEW trades_hourly SET TTL 7 DAYS;
+```
+
+A view's TTL is independent of its base table's TTL. For full syntax, see
+[CREATE MATERIALIZED VIEW](/docs/query/sql/create-mat-view/#ttl-time-to-live)
+and
+[ALTER MATERIALIZED VIEW SET TTL](/docs/query/sql/alter-mat-view-set-ttl/).
+
 ## How TTL works
 
 TTL drops partitions based on the **partition's time range**, not individual row


### PR DESCRIPTION
## What

The [TTL concept page](https://questdb.com/docs/concept/ttl/) documents `TTL` only for tables under **Setting TTL** (at table creation and on existing tables). Materialized views are mentioned only in the Enterprise caution at the top, so a reader looking for how to apply TTL to a view on Open Source has no path.

This adds an **On materialized views** subsection under **Setting TTL**, mirroring the existing table subsections, covering TTL both at view creation and on an existing view, and linking the canonical SQL references.

## Why

Materialized views fully support TTL:

- `CREATE MATERIALIZED VIEW ... PARTITION BY DAY TTL 7 DAYS` — see [create-mat-view.md](https://questdb.com/docs/query/sql/create-mat-view/#ttl-time-to-live)
- `ALTER MATERIALIZED VIEW ... SET TTL 7 DAYS` — see [alter-mat-view-set-ttl.md](https://questdb.com/docs/query/sql/alter-mat-view-set-ttl/)

The examples reuse the exact syntax already documented in those pages; no new behavior is introduced.

Closes #275