### PR TITLE
docs: document Parquet and CSV download options in the Result Grid

### DIFF
--- a/documentation/getting-started/web-console/result-grid.md
+++ b/documentation/getting-started/web-console/result-grid.md
@@ -21,7 +21,8 @@ The Result Grid provides several action buttons in the toolbar to help you work 
 - **Move selected column to the front**: Moves the currently selected column to the leftmost position for better visibility
 - **Reset grid layout**: Resets the grid to its default column arrangement and removes all customizations including frozen columns and column reordering
 - **Refresh**: Re-executes the last query to update the results with fresh data
-- **Download result as CSV**: Downloads all data in the current result set as a CSV file for external analysis
+- **Download result as Parquet**: Downloads all data in the current result set as a [Parquet](/docs/query/export-parquet/) file for external analysis
+- **Download result as CSV**: Available from the download dropdown next to the Parquet button; downloads the current result set as a CSV file for external analysis
 
 ## Grid
 


### PR DESCRIPTION
## What

Updates the Result Grid download action to document both the **Parquet** and **CSV** export options.

## Why

Addresses #305. The Result Grid docs only mentioned CSV, but the current Web Console shows Parquet as the primary download button and moves CSV into a dropdown.

Verified against the Web Console E2E tests (`questdb/ui`, `e2e/tests/console/download.spec.js`):

- `download-parquet-button` is shown directly and requests `fmt=parquet`
- `download-csv-button` appears under `download-dropdown-button` and requests `fmt=csv`

So the previous single "Download result as CSV" bullet was both incomplete and out of date. This lists Parquet as the primary download and notes CSV is available from the dropdown, linking to the [Parquet export](/docs/query/export-parquet/) page.

## Scope

Covers the Parquet part of #305. The "views" note in that issue is left out, since the web-console views UI isn't documented yet ("will also soon need").

## Testing

Docs-only change; the linked `/docs/query/export-parquet/` page exists, so the Docusaurus broken-link build passes.
