### PR TITLE
fix(docs): remove QDB_CAIRO_ROOT from the Docker Compose example

### DIFF
--- a/documentation/configuration/cairo-engine.md
+++ b/documentation/configuration/cairo-engine.md
@@ -25,6 +25,13 @@ The locale used to handle date types.
 Directory for storing database tables and metadata. This directory is relative
 to the server root directory provided at startup.
 
+If you set it to an absolute path, QuestDB no longer derives its other
+directories from the server root directory. The `conf`, `import`, `export`,
+`tmp` and `.checkpoint` directories are then created as siblings of the
+directory you specify, rather than as children of the server root directory.
+Under Docker this places them outside the mounted volume, so leave `cairo.root`
+at its default and change the volume mapping instead.
+
 ### cairo.system.table.prefix
 
 - **Default**: `sys.`

--- a/documentation/cookbook/operations/docker-compose-config.md
+++ b/documentation/cookbook/operations/docker-compose-config.md
@@ -70,21 +70,57 @@ This configuration:
 
 
 :::warning Volume Permissions
-If you encounter permission errors with mounted volumes, ensure the QuestDB container user has write access to the host directory. You may need to set ownership with `chown -R 1000:1000 ./questdb_root` or run the container with a specific user ID.
+By default the `questdb/questdb` image starts as `root`, takes ownership of the
+mounted data directory, and then drops privileges to its own `questdb` user. In
+most cases you do not need to do anything.
+
+If you pin the container user with `user:`, the entrypoint can no longer fix
+ownership, so the host directory must already be writable by the uid and gid you
+pin.
 :::
 
 ## Custom data directory permissions
 
-```yaml title="Run with specific user/group for volume permissions"
+Pin the container user when you want QuestDB to write files as a specific
+account on the host, for example so that the data directory stays readable by
+your own user. Set `user:` to a uid and gid that owns the host directory, which
+is often `1000:1000` for the first non-root account on a Linux host. Run
+`id -u` and `id -g` to check:
+
+```yaml title="Run with a specific user/group for volume permissions"
 services:
   questdb:
     image: questdb/questdb
     user: "1000:1000"
-    environment:
-      - QDB_CAIRO_ROOT=/var/lib/questdb
     volumes:
       - ./questdb_data:/var/lib/questdb
 ```
+
+Make sure that user owns the host directory before starting the container:
+
+```bash
+mkdir -p questdb_data && sudo chown -R 1000:1000 questdb_data
+```
+
+:::caution Do not set `QDB_CAIRO_ROOT` in Docker
+The Docker image already uses `/var/lib/questdb` as its root directory, so
+`QDB_CAIRO_ROOT` is unnecessary. Setting it to an absolute path also changes how
+QuestDB derives its other directories: they become siblings of the data
+directory rather than children of the root directory.
+
+With `QDB_CAIRO_ROOT=/var/lib/questdb`, the checkpoint, import, export and
+temporary directories move to `/var/lib/.checkpoint`, `/var/lib/import`,
+`/var/lib/export` and `/var/lib/tmp` — all outside the mounted volume, in a
+directory the container user cannot write to. `CHECKPOINT CREATE` then fails
+with an error such as:
+
+```
+Could not create [dir=/var/lib/.checkpoint//var/lib/questdb/]
+```
+
+To change where data is stored on the host, change the left-hand side of the
+volume mapping instead.
+:::
 
 ## Complete configuration reference
 


### PR DESCRIPTION
## Problem

The "Custom data directory permissions" example on [Configure QuestDB with Docker Compose](https://questdb.com/docs/cookbook/operations/docker-compose-config/) sets `QDB_CAIRO_ROOT=/var/lib/questdb`. This was reported by a customer on 9.4.3, whose `CHECKPOINT CREATE` failed with:

```
Could not create [dir=/var/lib/.checkpoint//var/lib/questdb/]
```

The variable is both **unnecessary** and **harmful**:

- **Unnecessary** — `docker-entrypoint.sh` already passes `-d /var/lib/questdb` as the install root, so the data directory is `/var/lib/questdb` with or without it.
- **Harmful** — an absolute `cairo.root` flips `PropServerConfiguration` into a different branch (`PropServerConfiguration.java:971`) in which every other directory is derived as a *sibling* of the data directory rather than a *child* of the root directory.

Measured against the real config object, mirroring the container layout:

| root | correct (no `QDB_CAIRO_ROOT`) | following the example |
| --- | --- | --- |
| db | `/var/lib/questdb/db` | `/var/lib/questdb` |
| checkpoint | `/var/lib/questdb/.checkpoint` | `/var/lib/.checkpoint` ⚠️ |
| conf | `/var/lib/questdb/conf` | `/var/lib/conf` ⚠️ |
| import | `/var/lib/questdb/import` | `/var/lib/import` ⚠️ |
| export | `/var/lib/questdb/export` | `/var/lib/export` ⚠️ |
| copy work | `/var/lib/questdb/tmp` | `/var/lib/tmp` ⚠️ |

Everything marked ⚠️ lands outside the mounted volume, in root-owned `/var/lib`, which the container user cannot write to. Anyone following this example has a database whose checkpoint, import, export and temp directories are all outside their volume.

The doubled slash in the error is a second effect: with an absolute `cairo.root`, `getDbDirectory()` returns the full path instead of `"db"`, and `DatabaseCheckpointAgent.java:204` concatenates it as a relative segment.

## Changes

- Remove `QDB_CAIRO_ROOT` from the Compose example and add a caution explaining why it must not be set under Docker.
- Document the absolute-path behaviour on the `cairo.root` reference entry, which previously only described the relative case.
- Rewrite the "Volume Permissions" warning, which described default image behaviour inaccurately. The image starts as root, takes ownership of the data directory and then drops privileges; pinning `user:` is what skips that step, so the host directory must already be writable by the pinned uid.

`user: "1000:1000"` is kept — for a bind mount the kernel checks the numeric uid against the host directory's owner, and 1000 is the usual first non-root account on a Linux host.

## Follow-up (not in this PR)

Worth hardening core so this surfaces as a config error rather than a nonsense path: either have `DatabaseCheckpointAgent` use the leaf directory name rather than `getDbDirectory()` verbatim (used as a relative segment in ~12 places there), or reject an absolute `cairo.root` at boot.

## Testing

- Derived roots in the table above were produced by instantiating the real `PropServerConfiguration` with and without an absolute `cairo.root`, against a writable mirror of the container layout — with a matched control.
- MDX of both changed files compiles. `npm run build` fails in this environment inside the `fetch-repo` plugin (network fetch of `github-api.questdb.io` returns non-JSON) before MDX compilation, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)