### PR TITLE
docs: update the August 2026 changelog

### DIFF
--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -10,16 +10,28 @@ This page tracks significant updates to the QuestDB documentation.
 
 ## August 2026
 
+### New
+
+- [ALTER TABLE SET FORMAT](/docs/query/sql/alter-table-set-format/) - New reference page for switching a table's partition storage format between `NATIVE` and `PARQUET`
+
+### Reference
+
+- [CREATE TABLE](/docs/query/sql/create-table/#partition-format) - Added the `FORMAT { NATIVE | PARQUET }` clause to store partitions as Parquet by default on partitioned WAL tables
+- [SHOW CREATE MATERIALIZED VIEW](/docs/query/sql/show/#show-create-materialized-view) - Documented retrieving a materialized view's `CREATE` statement, and alphabetized the SHOW reference page
+- [SHOW CREATE DATABASE](/docs/query/sql/show/#show-create-database) - Documented dumping the whole database schema as round-trippable DDL, with `INCLUDE`/`EXCLUDE` category filtering
+- [EXPLAIN](/docs/query/sql/explain/) - Added the `Encode sort` / `Encode sort light` plan node to the plan-node reference
+- [LIMIT](/docs/query/sql/limit/#null-bounds) - Documented null `LIMIT` bounds (supplied via bind variables) and their two-bound semantics
+- Added the [`cairo.sql.parquet.cache.memory.size`](/docs/configuration/cairo-engine/) configuration property (256 MB default), deprecating the slot-based `cairo.sql.parquet.frame.cache.capacity`
+- Documented [`cairo.root`](/docs/configuration/cairo-engine/) absolute-path behavior: the `conf`, `import`, `export`, `tmp`, and `.checkpoint` directories become siblings of the specified directory rather than children of the server root, so leave it at the default under Docker
+
 ### Updated
 
+- [Parquet](/docs/concepts/parquet/) - Moved the Parquet page to Concepts and revamped it around creating tables as Parquet, in-place conversion (storage policies and `ALTER TABLE`), and export; also documented `ALTER COLUMN TYPE` on Parquet partitions and relaxed the in-place conversion constraints
+- [Storage engine](/docs/architecture/storage-engine/) - Reworked the three-tier storage model: local native or Parquet storage, then remote object storage
 - [systemd deployment](/docs/deployment/systemd/) - Reworked the systemd service guide to cover both QuestDB Open Source and Enterprise
 - [Time to live (TTL)](/docs/concepts/ttl/) - Documented TTL on materialized views, set with `CREATE MATERIALIZED VIEW ... TTL` or `ALTER MATERIALIZED VIEW ... SET TTL` and managed independently of the base table's TTL
 - [Result grid](/docs/getting-started/web-console/result-grid/) - Documented the Parquet and CSV download options in the web console result grid
 - [Docker Compose configuration](/docs/cookbook/operations/docker-compose-config/) - Reworked the volume-permission guidance and explained why `QDB_CAIRO_ROOT` should not be set in Docker
-
-### Reference
-
-- Documented [`cairo.root`](/docs/configuration/cairo-engine/) absolute-path behavior: the `conf`, `import`, `export`, `tmp`, and `.checkpoint` directories become siblings of the specified directory rather than children of the server root, so leave it at the default under Docker
 
 ## July 2026
 


### PR DESCRIPTION
## Summary

Expands the August 2026 changelog with the recently merged documentation work:

- **New**: `ALTER TABLE SET FORMAT` reference page
- **Reference**: CREATE TABLE `FORMAT` clause, SHOW CREATE MATERIALIZED VIEW, SHOW CREATE DATABASE, the EXPLAIN `Encode sort` node, null `LIMIT` bounds, and the `cairo.sql.parquet.cache.memory.size` config
- **Updated**: the Parquet page move to Concepts and revamp, ALTER COLUMN TYPE on Parquet partitions, and the storage-engine three-tier rework

Also reorders the August section into the standard New → Reference → Updated category order.