### PR TITLE
Document HTTP authentication for the REST API and Telegraf

### DIFF
--- a/documentation/cookbook/integrations/opcua-dense-format.md
+++ b/documentation/cookbook/integrations/opcua-dense-format.md
@@ -4,7 +4,7 @@ sidebar_label: OPC-UA dense format
 description: Configure Telegraf to merge sparse OPC-UA metrics into dense rows for efficient storage and querying in QuestDB
 ---
 
-Configure Telegraf to collect OPC-UA industrial automation data and insert it into QuestDB in a dense format. By default, Telegraf creates one row per metric with sparse columns, but for QuestDB it's more efficient to merge all metrics from the same timestamp into a single dense row.
+Configure [Telegraf](/docs/ingestion/message-brokers/telegraf/) to collect OPC-UA industrial automation data and insert it into QuestDB in a dense format. By default, Telegraf creates one row per metric with sparse columns, but for QuestDB it's more efficient to merge all metrics from the same timestamp into a single dense row.
 
 ## Problem: Sparse data format
 
@@ -78,9 +78,17 @@ Configure Telegraf to merge metrics with matching timestamps and tags before sen
 # QuestDB Output via ILP
 [[outputs.influxdb_v2]]
   urls = ["${QUESTDB_HTTP_ENDPOINT}"]
+  # QuestDB Enterprise: a REST API token
   token = "${QUESTDB_HTTP_TOKEN}"
+  # QuestDB Open Source: base64-encoded "user:password" instead of a token
+  # http_headers = {"Authorization" = "Basic ${QUESTDB_BASIC_AUTH}"}
   content_encoding = "identity"
 ```
+
+The two credential lines are alternatives, so use whichever matches your
+edition. For how to generate a token or encode the basic credentials, see
+[authentication](/docs/ingestion/message-brokers/telegraf/#authentication) on
+the Telegraf page.
 
 ### Key configuration elements
 
@@ -298,8 +306,8 @@ OPC-UA timestamps may have different precision than QuestDB expects. Ensure:
 :::
 
 :::info Related Documentation
+- [Telegraf integration](/docs/ingestion/message-brokers/telegraf/)
 - [Telegraf OPC-UA plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/opcua)
 - [Telegraf merge aggregator](https://github.com/influxdata/telegraf/tree/master/plugins/aggregators/merge)
 - [QuestDB ILP reference](/docs/ingestion/ilp/overview/)
-- [InfluxDB Line Protocol](/docs/ingestion/ilp/overview/)
 :::

--- a/documentation/ingestion/message-brokers/telegraf.md
+++ b/documentation/ingestion/message-brokers/telegraf.md
@@ -84,7 +84,7 @@ section of the server configuration page.
 Create a new file named `questdb.conf` in one of the locations Telegraf can
 load configuration files from and paste the following example:
 
-```shell title="/path/to/telegraf/config/questdb.conf" - Base plugins
+```shell title="/path/to/telegraf/config/questdb.conf - Base plugins"
 # Configuration for Telegraf agent
 [agent]
   ## Default data collection interval for all inputs
@@ -131,6 +131,37 @@ aggregator plugin will instead roll them into a more "dense" row as desired.
   drop_original = true
 
 ```
+
+### Authentication
+
+The configuration above assumes an unsecured instance. If your QuestDB instance
+requires authentication, add the credentials to the `outputs.influxdb_v2`
+plugin. The method depends on the edition.
+
+QuestDB Enterprise accepts a REST API token. Telegraf builds the
+`Authorization` header for you through the `token` setting:
+
+```shell title="/path/to/telegraf/config/questdb.conf - QuestDB Enterprise"
+[[outputs.influxdb_v2]]
+  urls = ["http://localhost:9000"]
+  token = "${QUESTDB_HTTP_TOKEN}"
+```
+
+QuestDB Open Source supports HTTP basic authentication and cannot generate
+tokens, so set the header yourself. Base64-encode the username and password
+joined by a colon, then send the result with the `Basic` scheme:
+
+```shell title="/path/to/telegraf/config/questdb.conf - QuestDB Open Source"
+[[outputs.influxdb_v2]]
+  urls = ["http://localhost:9000"]
+  http_headers = {"Authorization" = "Basic ${QUESTDB_BASIC_AUTH}"}
+```
+
+Here `QUESTDB_BASIC_AUTH` holds the encoded credentials, not the raw password.
+See [building the Authorization header manually](/docs/query/rest-api/#building-the-authorization-header-manually)
+for how to produce that value, and
+[authentication via token](/docs/query/rest-api/#authentication-via-token-in-questdb-enterprise)
+for how to generate an Enterprise REST API token.
 
 Run Telegraf and specify the configuration file with the QuestDB output:
 

--- a/documentation/query/rest-api.md
+++ b/documentation/query/rest-api.md
@@ -732,25 +732,43 @@ A HTTP status code of `400` is returned with the following response body:
 }
 ```
 
-## Authentication (RBAC)
+## Authentication
+
+The REST API supports two authentication types:
+
+- **HTTP basic authentication**, available in QuestDB Open Source and QuestDB
+  Enterprise.
+- **Token-based authentication**, available in QuestDB Enterprise only.
 
 :::note
 
 Role-based Access Control (RBAC) is available in
-[QuestDB Enterprise](/enterprise/). See the next paragraph for authentication in
-QuestDB Open Source.
+[QuestDB Enterprise](/enterprise/). On QuestDB Enterprise, prefer
+[token-based authentication](#authentication-via-token-in-questdb-enterprise)
+over basic authentication.
 
 :::
 
-REST API supports two authentication types:
+### HTTP basic authentication
 
-- HTTP basic authentication
-- Token-based authentication
+Basic authentication is the method web browsers use when they prompt for a
+username and password, and it is the only method available in QuestDB Open
+Source.
 
-The first authentication type is mainly supported by web browsers. But you can
-also apply user credentials programmatically in a `Authorization: Basic` header.
-This example `curl` command that executes a `SELECT 1;` query along with the
-`Authorization: Basic` header:
+In QuestDB Open Source, enable it by setting the configuration options
+`http.user` and `http.password` in `server.conf`:
+
+```shell
+http.user=my_user
+http.password=my_password
+```
+
+In QuestDB Enterprise, basic authentication uses the password of an existing
+database user, so there is nothing to enable in `server.conf`.
+
+You can also apply the credentials programmatically in an `Authorization: Basic`
+header. The `curl` flag `-u` builds that header for you. This example executes a
+`SELECT 1;` query:
 
 ```bash
 curl -G --data-urlencode "query=SELECT 1;" \
@@ -758,8 +776,48 @@ curl -G --data-urlencode "query=SELECT 1;" \
     http://localhost:9000/exec
 ```
 
-The second authentication type requires a REST API token to be specified in a
-`Authorization: Bearer` header:
+#### Building the Authorization header manually
+
+Not every HTTP client has an equivalent of curl's `-u` flag. In that case, build
+the header value yourself: join the username and password with a colon, then
+Base64-encode the result.
+
+```bash
+printf 'my_user:my_password' | base64
+# bXlfdXNlcjpteV9wYXNzd29yZA==
+```
+
+Use `printf` rather than `echo`, which appends a newline that ends up encoded as
+part of the password.
+
+Send the encoded value using the `Basic` scheme:
+
+```bash
+curl -G --data-urlencode "query=SELECT 1;" \
+    -H "Authorization: Basic bXlfdXNlcjpteV9wYXNzd29yZA==" \
+    http://localhost:9000/exec
+```
+
+The colon is the delimiter, so the username cannot contain one. Passwords can,
+since everything after the first colon is treated as the password.
+
+:::note
+
+Base64 is an encoding, not encryption. Anyone who can read the header can
+recover the credentials, so only send basic authentication over HTTPS or on a
+trusted network.
+
+:::
+
+### Authentication via token in QuestDB Enterprise
+
+Token-based authentication is the recommended method for programmatic access on
+QuestDB Enterprise. Unlike a password, a REST API token can be issued to a user
+or a service account, carries its own permission granularity, can be given an
+expiry, and can be revoked on its own without disrupting the user's other
+credentials.
+
+Specify the token in an `Authorization: Bearer` header:
 
 ```bash
 curl -G --data-urlencode "query=SELECT 1;" \
@@ -769,24 +827,3 @@ curl -G --data-urlencode "query=SELECT 1;" \
 
 Refer to the [user management](/docs/security/rbac/#user-management) page to
 learn more on how to generate a REST API token.
-
-## Authentication in QuestDB open source
-
-QuestDB Open Source supports HTTP basic authentication. To enable it, set the
-configuration options `http.user` and `http.password` in `server.conf`.
-
-The following example shows how to enable HTTP basic authentication in QuestDB
-open source:
-
-```shell
-http.user=my_user
-http.password=my_password
-```
-
-Then this `curl` command executes a `SELECT 1;` query:
-
-```bash
-curl -G --data-urlencode "query=SELECT 1;" \
-    -u "my_user:my_password" \
-    http://localhost:9000/exec
-```


### PR DESCRIPTION
## Summary

Restructures the REST API authentication section and documents how to authenticate from Telegraf.

- `query/rest-api.md`: merges the two overlapping authentication sections into one `## Authentication` section with subsections for basic auth and Enterprise token auth. Adds instructions for building the `Authorization: Basic` header manually, for clients without a curl-style `-u` flag. Recommends token auth over basic auth on Enterprise.
- `ingestion/message-brokers/telegraf.md`: new authentication subsection showing the Enterprise `token` setting and the Open Source `http_headers` basic-auth equivalent.
- `cookbook/integrations/opcua-dense-format.md`: labels the credential lines in the example config, links to the Telegraf authentication section, links the first mention of Telegraf to our own page, and removes a duplicate entry from Related Documentation.

Note the three files are interdependent: the Telegraf and OPC-UA pages link to anchors introduced in `rest-api.md`, so they need to land together.