### PR TITLE
Sync integrations overview with the sidebar and add a Data Ingestion entry

### DIFF
--- a/.claude/skills/questdb-docs-writer/SKILL.md
+++ b/.claude/skills/questdb-docs-writer/SKILL.md
@@ -407,6 +407,109 @@ actually does.
 Structure: Intro (what it does in one sentence) - Syntax - How it works
 (precise mechanics) - Examples (demoable) - Limitations.
 
+## Overview page sync
+
+Several sections have an overview or index page that lists every page in that
+section (e.g. `integrations/overview.md`, `cookbook/sql/finance/index.md`).
+These lists go stale silently: nothing in the build checks that the overview
+matches `sidebars.js`, so a missing entry is invisible until a reader can't
+find a page.
+
+**Whenever you add or remove a page in a section that has an overview page,
+update that overview in the same change. Do it automatically, without
+asking.**
+
+- **Adding a page**: add a bullet to the overview, in the section that
+  corresponds to its `sidebars.js` category.
+- **Removing a page**: delete its bullet from the overview.
+- **Renaming a page**: update the label and the link.
+
+Never leave an overview listing a page that no longer exists, or omitting one
+that does.
+
+### Match the sidebar, not your own judgement
+
+The overview must mirror `sidebars.js`, not what seems logically tidy:
+
+- **Section order** follows the sidebar's category order.
+- **Item order within a section** follows the sidebar's item order. That order
+  is curated, not alphabetical. Do not re-sort it alphabetically, and do not
+  "fix" it, even when it looks arbitrary.
+- **Section headings** should correspond to the sidebar's category labels.
+
+Where a page lives in the sidebar decides which overview section it belongs
+to. A page under the `Other Tools` sidebar category goes in the overview's
+"other tools" section even if its subject matter sounds like ingestion or
+analytics.
+
+### Do not rename existing headings
+
+Overview headings are anchor targets. Renaming `## Tooling and Interfaces` to
+`## Other Tools` changes `#tooling-and-interfaces` to `#other-tools` and
+breaks every inbound link.
+
+Only rename a heading when the user explicitly asks. When you do, first grep
+both repos for the old anchor and report what you find:
+
+```
+grep -rn --exclude-dir=node_modules --exclude-dir=.git \
+  --exclude-dir=build --exclude-dir=.docusaurus "old-anchor-slug" .
+```
+
+Adding, removing, and reordering bullets is safe. Renaming headings is not.
+
+### Moving a page between sections
+
+Moving a page across sidebar categories is not a mechanical edit. **Stop and
+ask the user** which outcome they want:
+
+1. **Point to the new location**: move the entry to the new section, leaving
+   one canonical home. Usually correct.
+2. **Duplicate it**: list it in both sections. Warn the user first, see below.
+3. **Remove it**: drop it from the overview entirely.
+
+Never pick one silently.
+
+### Why duplicate sidebar entries misbehave
+
+If the user wants the same page reachable from two sidebar categories, tell
+them what actually happens: **both categories highlight and auto-expand at
+once** whenever that page is open.
+
+This is not a bug and there is no config to disable it. In
+`@docusaurus/plugin-content-docs/src/client/docsUtils.tsx`:
+
+```js
+if (item.type === 'link') {
+  return isActive(item.href, activePath);
+}
+```
+
+Activeness is decided purely by URL. Authored `type: "doc"` entries are
+compiled to `type: 'link'` props carrying an href, so a `type: "link"` entry
+behaves identically to a duplicated doc id. There is no way to duplicate an
+entry without duplicating the highlight. Then in
+`@docusaurus/theme-classic/src/theme/DocSidebarItem/Category/index.tsx`:
+
+```js
+initialState: () => (isActive ? false : item.collapsed)
+```
+
+An active category always initializes expanded, reinforced by
+`useAutoExpandActiveCategory`.
+
+The one escape hatch: `isSamePath` compares normalized path strings and does
+**not** strip fragments, so an href containing `#` can never equal
+`activePath`. A cross-reference link with an anchor never highlights and never
+auto-expands:
+
+```js
+{ type: "link", label: "Message Brokers",
+  href: "/docs/integrations/overview/#data-ingestion-and-streaming" },
+```
+
+Prefer this, or a plain link in the overview body, over duplicating an entry.
+
 ## Configuration property sync
 
 When documenting a feature that introduces a new server configuration property
@@ -665,6 +768,9 @@ When reviewing a documentation page, check:
 - [ ] Result tables only where output is predictable
 - [ ] `yarn build` passes (no broken links)
 - [ ] Sidebar updated if new pages were added (`sidebars.js`)
+- [ ] Section overview page updated for any added, removed, or renamed page,
+      with section and item order matching `sidebars.js`
+- [ ] No overview heading renamed without checking inbound anchors first
 - [ ] New config properties added to `configuration/configuration-utils/_cairo.config.json`
 - [ ] New keywords/functions/types checked against `questdb/sql-parser` repo
       (default branch and open PRs)

--- a/documentation/integrations/overview.md
+++ b/documentation/integrations/overview.md
@@ -18,11 +18,13 @@ platforms:
 
 - **[Grafana](/docs/integrations/visualization/grafana/):** Create stunning dashboards
   and interactive graphs for [time-series data](/blog/what-is-time-series-data/) visualization.
+- [qStudio](/docs/integrations/visualization/qstudio/): A free SQL GUI for query
+  execution, table browsing, and result charting.
 - [Superset](/docs/integrations/visualization/superset/): Build interactive
   visualizations and perform ad-hoc data analysis.
 - **[PowerBI](/docs/integrations/visualization/powerbi/):** Create interactive data visualizations and dashboards.
-- [qStudio](/docs/integrations/visualization/qstudio/): A free SQL GUI for query
-  execution, table browsing, and result charting.
+- [Embeddable](/docs/integrations/visualization/embeddable/): A developer toolkit
+  for building customer-facing analytics directly into your app.
 
 ## Data Ingestion and Streaming
 
@@ -37,6 +39,17 @@ integrations:
   platform for simplified data pipelines.
 - [Apache Flink](/docs/ingestion/message-brokers/flink/): Process real-time data streams
   efficiently.
+
+## Analytics and Processing
+
+Enhance your data analysis and processing capabilities with QuestDB through
+these tools:
+
+- [Pandas](/docs/integrations/data-processing/pandas/): Analyze [time-series data](/blog/what-is-time-series-data/) in Python
+  with powerful data structures.
+- [Polars](/docs/integrations/data-processing/polars/): Process large datasets
+  efficiently with a fast DataFrame library implemented in Rust and Python.
+- [Apache Spark](/docs/integrations/data-processing/spark/): Handle complex data processing
   tasks at scale.
 
 ## Workflow Orchestrators
@@ -48,18 +61,7 @@ Automate your data pipelines with these workflow orchestrators:
 - [Dagster](/docs/integrations/orchestration/dagster/): A modern workflow orchestrator for
   data pipelines.
 
-## Analytics and Processing
-
-Enhance your data analysis and processing capabilities with QuestDB through
-these tools:
-
-- [Pandas](/docs/integrations/data-processing/pandas/): Analyze [time-series data](/blog/what-is-time-series-data/) in Python
-  with powerful data structures.
-- [MindsDB](/docs/integrations/other/mindsdb/): Build machine learning models for
-  predictive analytics on [time-series data](/blog/what-is-time-series-data/).
-- [Apache Spark](/docs/integrations/data-processing/spark/): Handle complex data processing
-
-## Tooling and Interfaces
+## Other Tools
 
 Improve your interactions with QuestDB using these tools and interfaces:
 
@@ -67,6 +69,16 @@ Improve your interactions with QuestDB using these tools and interfaces:
   analyze monitoring metrics.
 - [SQLAlchemy](/docs/integrations/other/sqlalchemy/): Utilize Python's ORM
   capabilities for database interactions.
+- [MindsDB](/docs/integrations/other/mindsdb/): Build machine learning models for
+  predictive analytics on [time-series data](/blog/what-is-time-series-data/).
+- [Databento](/docs/integrations/other/databento/): Ingest a normalized live
+  market data feed covering multiple venues.
+- [Cube](/docs/integrations/other/cube/): Middleware connecting your data sources
+  to your data applications.
+- [Ignition](/docs/integrations/other/ignition/): A software suite for industrial
+  automation, including SCADA and IIoT integrations.
+- [Airbyte](/docs/integrations/other/airbyte/): Sync data from a wide range of
+  sources into QuestDB with an open-source ETL platform.
 
 Is there an integration you'd like to see that's not listed? Let us know by
 opening an issue on [QuestDB Github](https://github.com/questdb/questdb/issues/new/choose).

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -733,6 +733,16 @@ module.exports = {
           ],
         },
         {
+          // Message brokers live under Ingestion. This is a cross-reference to
+          // the overview section that lists them. The fragment is deliberate:
+          // Docusaurus decides sidebar activeness by comparing normalized
+          // paths without stripping it, so this link never highlights and
+          // never auto-expands a second category.
+          type: "link",
+          label: "Data Ingestion",
+          href: "/docs/integrations/overview/#data-ingestion-and-streaming",
+        },
+        {
           type: "category",
           label: "Data Processing",
           collapsed: true,


### PR DESCRIPTION
## Summary

The integrations overview had drifted from `sidebars.js`, and message brokers were not discoverable from the Integrations sidebar.

- `integrations/overview.md`: adds the six pages that were in the sidebar but missing from the page (Embeddable, Polars, Airbyte, Cube, Databento, Ignition), removes a duplicate Related link, and fixes an orphaned sentence fragment that had been stranded under Flink instead of Spark. Renames `## Tooling and Interfaces` to `## Other Tools` to match its sidebar category, and moves MindsDB into it. Section and item order now follow the sidebar.
- `sidebars.js`: adds a `Data Ingestion` cross-reference link under Integrations, pointing at the overview's ingestion section. Message brokers keep their canonical home under Ingestion.
- `.claude/skills/questdb-docs-writer/SKILL.md`: documents the overview sync rule so this drift does not recur.

The sidebar link deliberately carries a URL fragment. Docusaurus decides sidebar activeness by comparing normalized paths without stripping fragments, so the link never highlights and never auto-expands a second category. Duplicating the entries instead would make two categories expand at once whenever a broker page is open.

Checked that nothing links to the old `#tooling-and-interfaces` anchor in either repo before renaming it.