### PR TITLE
Update the August 2026 changelog

### DIFF
--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -10,13 +10,36 @@ This page tracks significant updates to the QuestDB documentation.
 
 ## August 2026
 
+### Releases
+
+- [10.0.0](https://questdb.com/release-notes/) - Released August 6, 2026
+
 ### New
 
+- [Connect](/docs/connect/overview/) - New top-level Connect section that gathers the native client libraries, the compatibility protocols (ILP, PGWire, REST), and the wire-protocol specifications under one home, with a decision table for picking a path and a per-language QWP support matrix
+- [Connect string reference](/docs/connect/clients/connect-string/) - Every configuration key for the native clients, with worked connect strings for common setups, a goal-to-keys recipe table, sender restart and replay semantics, and an alphabetical key index
+- [Wire protocols](/docs/connect/wire-protocols/overview/) - QWP specifications for client implementers, covering [ingress over WebSocket](/docs/connect/wire-protocols/qwp-ingress-websocket/), [egress over WebSocket](/docs/connect/wire-protocols/qwp-egress-websocket/), and [expected client behavior](/docs/connect/wire-protocols/qwp-client-behavior/)
+- [Store-and-forward](/docs/high-availability/store-and-forward/when-to-use/) - New section on client-side disk buffering: choosing between memory mode and disk-backed offload, [concepts](/docs/high-availability/store-and-forward/concepts/), [configuration](/docs/high-availability/store-and-forward/configuration/), and [operating and tuning](/docs/high-availability/store-and-forward/operating-and-tuning/)
+- [Client failover](/docs/high-availability/client-failover/concepts/) - How clients detect a failed primary and switch to a healthy peer using multi-host address lists, host-health classification, role filtering, and zone-aware selection, plus its [configuration](/docs/high-availability/client-failover/configuration/)
+- [Delivery semantics](/docs/concepts/delivery-semantics/) - At-least-once delivery, where duplicate rows arise, and how designated timestamps combine with deduplication for exactly-once outcomes
+- [Agents](/docs/connect/agents/) - Which protocols AI agents use to drive QuestDB, the tooling available to them, and how to grant scoped access
+- [Live views](/docs/concepts/live-views/) - Incrementally maintained window-function queries over a WAL table, queried like a regular table, with [CREATE LIVE VIEW](/docs/query/sql/create-live-view/), [DROP LIVE VIEW](/docs/query/sql/drop-live-view/), and the [`cairo.live.view.*` settings](/docs/configuration/live-views/)
+- [Notebooks](/docs/getting-started/web-console/notebooks/overview/) - Web Console notebooks that combine SQL, markdown, and charts in one tab, covering [cells](/docs/getting-started/web-console/notebooks/cells/), [charts](/docs/getting-started/web-console/notebooks/charts/), [variables](/docs/getting-started/web-console/notebooks/variables/), [live dashboards](/docs/getting-started/web-console/notebooks/live-dashboards/), and [sharing](/docs/getting-started/web-console/notebooks/manage-share/)
+- [MCP connection](/docs/getting-started/web-console/mcp-connection/) - Connect AI coding agents to the Web Console through the `@questdb/mcp-bridge` local MCP server, with the pairing flow, the four permission levels, and the available agent tools
+- [Register QuestDB Parquet as Apache Iceberg tables](/docs/tutorials/questdb-to-iceberg/) - Expose Parquet partitions as Iceberg tables and query them in place from Spark, Trino, DuckDB, or PyIceberg
+- [ALTER TABLE REBASE WAL](/docs/query/sql/alter-table-rebase-wal/) - New reference page for rebuilding a suspended WAL table under a fresh sequencer, with its requirements and permission
 - [ALTER TABLE SET FORMAT](/docs/query/sql/alter-table-set-format/) - New reference page for switching a table's partition storage format between `NATIVE` and `PARQUET`
+- [QWP configuration](/docs/configuration/qwp/) - Server-side settings for the QWP ingestion (`/write/v4`) and query (`/read/v1`) endpoints
 
 ### Reference
 
 - [CREATE TABLE](/docs/query/sql/create-table/#partition-format) - Added the `FORMAT { NATIVE | PARQUET }` clause to store partitions as Parquet by default on partitioned WAL tables
+- [REST API](/docs/connect/compatibility/rest-api/#authentication) - Merged the overlapping authentication sections into one, with basic auth (including building the `Authorization` header by hand) and Enterprise token auth
+- [SHOW CREATE LIVE VIEW](/docs/query/sql/show/#show-create-live-view) - Documented retrieving a live view's `CREATE` statement, alongside the `CREATE LIVE VIEW` and `DROP LIVE VIEW` [permissions](/docs/security/rbac/)
+- Added the [`live_views()`](/docs/query/functions/meta/#live_views) catalogue function and the `L` `table_type` discriminator to the meta functions page
+- Added the [`is_end_of_month()`](/docs/query/functions/date-time/#is_end_of_month) date-time function, which is leap-year aware and returns `false` for `null`
+- Documented the [`query.timeout`](/docs/configuration/cairo-engine/) duration key (`120s`, `1m`, `500ms`) alongside the now-deprecated `query.timeout.sec`, and how the two relate
+- Added the [`cairo.wal.apply.suspended.tables`](/docs/configuration/wal/) and `cairo.wal.apply.suspended.write.denied` configuration properties
 - [SHOW CREATE MATERIALIZED VIEW](/docs/query/sql/show/#show-create-materialized-view) - Documented retrieving a materialized view's `CREATE` statement, and alphabetized the SHOW reference page
 - [SHOW CREATE DATABASE](/docs/query/sql/show/#show-create-database) - Documented dumping the whole database schema as round-trippable DDL, with `INCLUDE`/`EXCLUDE` category filtering
 - [EXPLAIN](/docs/query/sql/explain/) - Added the `Encode sort` / `Encode sort light` plan node to the plan-node reference
@@ -26,6 +49,11 @@ This page tracks significant updates to the QuestDB documentation.
 
 ### Updated
 
+- Client libraries rewritten for the QWP binary protocol, unifying ingestion and streaming SQL queries under one handle: [Java](/docs/connect/clients/java/), [Python](/docs/connect/clients/python/), [Go](/docs/connect/clients/go/), [C & C++](/docs/connect/clients/c-and-cpp/), [Rust](/docs/connect/clients/rust/), and [.NET](/docs/connect/clients/dotnet/)
+- [Web Console](/docs/getting-started/web-console/overview/) - Documented query sharing by link and tab import/export in the [code editor](/docs/getting-started/web-console/code-editor/), custom AI providers and per-provider permission levels in [QuestDB AI](/docs/getting-started/web-console/questdb-ai/), automatic column sizing in the [result grid](/docs/getting-started/web-console/result-grid/), and the storage policy section in [table details](/docs/getting-started/web-console/table-details/)
+- [AI coding agents](/docs/getting-started/ai-coding-agents/) - Repositioned around the agent skill and the Web Console MCP bridge together
+- [Telegraf](/docs/connect/message-brokers/telegraf/#authentication) - Documented authenticating from Telegraf with the Enterprise `token` setting or the Open Source `http_headers` basic-auth equivalent
+- [Integrations overview](/docs/integrations/overview/) - Synced with the sidebar: added the six missing pages, moved MindsDB into Other Tools, and added a Data Ingestion cross-reference
 - [Parquet](/docs/concepts/parquet/) - Moved the Parquet page to Concepts and revamped it around creating tables as Parquet, in-place conversion (storage policies and `ALTER TABLE`), and export; also documented `ALTER COLUMN TYPE` on Parquet partitions and relaxed the in-place conversion constraints
 - [Storage engine](/docs/architecture/storage-engine/) - Reworked the three-tier storage model: local native or Parquet storage, then remote object storage
 - [systemd deployment](/docs/deployment/systemd/) - Reworked the systemd service guide to cover both QuestDB Open Source and Enterprise


### PR DESCRIPTION
## Summary

Adds the documentation changes merged since the last changelog refresh on August 3.

- **Releases**: 10.0.0, released August 6, 2026.
- **New**: the Connect supersection and connect-string reference, the QWP wire-protocol specs, store-and-forward, client failover, delivery semantics, the agents page, live views, Web Console notebooks and the MCP connection page, the Iceberg tutorial, ALTER TABLE REBASE WAL, and QWP server configuration.
- **Reference**: REST API authentication, SHOW CREATE LIVE VIEW and the live-view permissions, live_views(), is_end_of_month(), query.timeout, and the cairo.wal.apply.suspended.* properties.
- **Updated**: the client libraries rewritten for QWP, the Web Console pages, AI coding agents, Telegraf authentication, and the integrations overview sync.

The Go client rewrite is listed in both May (where the Connect PR filed it) and August alongside the other client libraries.