### PR TITLE
Document multi-dimensional numpy arrays in the QWP Python client

### DIFF
--- a/documentation/connect/clients/python.md
+++ b/documentation/connect/clients/python.md
@@ -287,46 +287,6 @@ strings in `columns` become `VARCHAR`. `DECIMAL` columns must be created
 ahead of time with `CREATE TABLE ... (price DECIMAL(18, 2), ...)`; the server
 does not auto-create them.
 
-#### Multi-dimensional arrays
-
-A numpy array keeps its shape on the wire, so an N-dimensional array lands in an
-N-dimensional QuestDB column. This is the natural fit for order book snapshots,
-where one row carries a whole book:
-
-```python
-import numpy as np
-import questdb
-from questdb import TimestampNanos
-
-# shape (2, N): row 0 = prices, row 1 = sizes
-bids = np.array([[64901.6, 64901.5], [3.02, 0.06]], dtype=np.float64)
-asks = np.array([[64901.7, 64901.8], [1.54, 0.21]], dtype=np.float64)
-
-with questdb.connect("ws::addr=localhost:9000;") as db:
-    with db.sender() as sender:
-        sender.row(
-            "order_book",
-            symbols={"symbol": "BTC-USDT"},
-            columns={"bids": bids, "asks": asks},
-            at=TimestampNanos.now(),
-        )
-        sender.flush(wait=True)
-```
-
-Auto-creation follows the shape you send: a 1D array creates `DOUBLE[]`, a 2D
-array `DOUBLE[][]`, a 3D array `DOUBLE[][][]`, and so on. Read the column back
-and you get a numpy array of the same shape.
-
-Only `float64` is accepted. Any other dtype is rejected before the row is sent:
-
-```python
-np.array([[1, 2], [3, 4]], dtype=np.int64)
-# QuestDBError: Only float64 numpy arrays are supported, got dtype: int64
-```
-
-Cast first with `arr.astype(np.float64)` when your source data is `float32` or
-an integer type.
-
 `UUID`, `IPv4`, `GEOHASH`, `LONG256`, `CHAR`, `DATE`, and `BINARY` columns
 have no `row()` value type. Route them through
 [`dataframe()`](#dataframe-ingestion), whose `schema_overrides` covers
@@ -375,6 +335,46 @@ rejections recorded since the lease was borrowed. FSNs are watermarks of
 the lease's pooled connection — use them while the lease is held; they are
 not portable across leases. Use `auto_flush=off` when
 `flush_and_get_fsn()` must define exact application batches.
+
+### Multi-dimensional arrays
+
+A numpy array keeps its shape on the wire, so an N-dimensional array lands in an
+N-dimensional QuestDB column. This is the natural fit for order book snapshots,
+where one row carries a whole book:
+
+```python
+import numpy as np
+import questdb
+from questdb import TimestampNanos
+
+# shape (2, N): row 0 = prices, row 1 = sizes
+bids = np.array([[64901.6, 64901.5], [3.02, 0.06]], dtype=np.float64)
+asks = np.array([[64901.7, 64901.8], [1.54, 0.21]], dtype=np.float64)
+
+with questdb.connect("ws::addr=localhost:9000;") as db:
+    with db.sender() as sender:
+        sender.row(
+            "order_book",
+            symbols={"symbol": "BTC-USDT"},
+            columns={"bids": bids, "asks": asks},
+            at=TimestampNanos.now(),
+        )
+        sender.flush(wait=True)
+```
+
+Auto-creation follows the shape you send: a 1D array creates `DOUBLE[]`, a 2D
+array `DOUBLE[][]`, a 3D array `DOUBLE[][][]`, and so on. Read the column back
+and you get a numpy array of the same shape.
+
+Only `float64` is accepted. Any other dtype is rejected before the row is sent:
+
+```python
+np.array([[1, 2], [3, 4]], dtype=np.int64)
+# QuestDBError: Only float64 numpy arrays are supported, got dtype: int64
+```
+
+Cast first with `arr.astype(np.float64)` when your source data is `float32` or
+an integer type.
 
 ## DataFrame ingestion
 

--- a/documentation/connect/clients/python.md
+++ b/documentation/connect/clients/python.md
@@ -275,7 +275,7 @@ The Python value type selects the QuestDB column type:
 | `float` | `DOUBLE` |
 | `str` | `VARCHAR` |
 | `TimestampMicros`, `TimestampNanos`, `datetime.datetime` | `TIMESTAMP`, `TIMESTAMP_NS` |
-| `numpy.ndarray` of `float64` | `DOUBLE[]`, QuestDB 9.0.0 or later |
+| `numpy.ndarray` of `float64`, any number of dimensions | `DOUBLE[]`, `DOUBLE[][]`, ... matching the array's shape. QuestDB 9.0.0 or later |
 | `decimal.Decimal` | `DECIMAL`, QuestDB 9.2.0 or later |
 | `None` | Column omitted for this row, stored as null |
 
@@ -286,6 +286,46 @@ Strings passed in the `symbols` dict become interned `SYMBOL` values;
 strings in `columns` become `VARCHAR`. `DECIMAL` columns must be created
 ahead of time with `CREATE TABLE ... (price DECIMAL(18, 2), ...)`; the server
 does not auto-create them.
+
+#### Multi-dimensional arrays
+
+A numpy array keeps its shape on the wire, so an N-dimensional array lands in an
+N-dimensional QuestDB column. This is the natural fit for order book snapshots,
+where one row carries a whole book:
+
+```python
+import numpy as np
+import questdb
+from questdb import TimestampNanos
+
+# shape (2, N): row 0 = prices, row 1 = sizes
+bids = np.array([[64901.6, 64901.5], [3.02, 0.06]], dtype=np.float64)
+asks = np.array([[64901.7, 64901.8], [1.54, 0.21]], dtype=np.float64)
+
+with questdb.connect("ws::addr=localhost:9000;") as db:
+    with db.sender() as sender:
+        sender.row(
+            "order_book",
+            symbols={"symbol": "BTC-USDT"},
+            columns={"bids": bids, "asks": asks},
+            at=TimestampNanos.now(),
+        )
+        sender.flush(wait=True)
+```
+
+Auto-creation follows the shape you send: a 1D array creates `DOUBLE[]`, a 2D
+array `DOUBLE[][]`, a 3D array `DOUBLE[][][]`, and so on. Read the column back
+and you get a numpy array of the same shape.
+
+Only `float64` is accepted. Any other dtype is rejected before the row is sent:
+
+```python
+np.array([[1, 2], [3, 4]], dtype=np.int64)
+# QuestDBError: Only float64 numpy arrays are supported, got dtype: int64
+```
+
+Cast first with `arr.astype(np.float64)` when your source data is `float32` or
+an integer type.
 
 `UUID`, `IPv4`, `GEOHASH`, `LONG256`, `CHAR`, `DATE`, and `BINARY` columns
 have no `row()` value type. Route them through


### PR DESCRIPTION
## What

The value types table on the QWP Python client page maps `numpy.ndarray` of `float64` to `DOUBLE[]` and stops there, which reads as though 1D arrays are all that is supported.

N-dimensional arrays work, and land in the matching N-dimensional column type. This adds the missing detail plus a short section with a runnable example.

## Why

Order book snapshots are a headline use case for QWP, and they need 2D. I hit this building an OKX order book pipeline: nothing on the page suggested 2D would work, so I had to test it rather than read it.

## Verified against 10.0.0

| numpy input | auto-created column |
| --- | --- |
| 1D `float64` | `DOUBLE[]` |
| 2D `float64` | `DOUBLE[][]` |
| 3D `float64` | `DOUBLE[][][]` |
| `float32` | rejected, `Only float64 numpy arrays are supported, got dtype: float32` |
| `int64` | rejected, `Only float64 numpy arrays are supported, got dtype: int64` |

The example in the diff was run verbatim against a local 10.0.0 instance. It auto-creates:

```
symbol SYMBOL, bids DOUBLE[][], asks DOUBLE[][], timestamp TIMESTAMP_NS
```

A 2D array also round-trips intact: shape `(2, 25)` in, shape `(2, 25)` numpy array back out of `to_pandas()`.

The dtype restriction is documented too, since it is easy to hit (market data often arrives as `float32` or ints) and was not mentioned anywhere on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)