### PR TITLE
Refresh the pandas and Polars pages for QWP

### DIFF
--- a/documentation/connect/clients/python.md
+++ b/documentation/connect/clients/python.md
@@ -503,7 +503,7 @@ print(frame)
 The `to_*` methods materialize the complete result; prefer the `iter_*`
 variants for large results. The PyCapsule protocol lets Arrow consumers read
 the result directly without pyarrow installed, for example
-`polars.from_arrow(result)`. For what each consumption style observes when
+`polars.DataFrame(result)`. For what each consumption style observes when
 the connection fails over mid-result, see
 [Failover and errors](#failover-and-errors).
 

--- a/documentation/connect/compatibility/pgwire/python.md
+++ b/documentation/connect/compatibility/pgwire/python.md
@@ -1090,7 +1090,12 @@ pip install pandas sqlalchemy questdb-connect
 :::note
 
 This example shows how to use the SQLAlchemy engine with psycopg2 for querying QuestDB into a pandas DataFrame.
-For ingestion from Pandas to QuestDB see our [pandas ingestion guide](/docs/integrations/data-processing/pandas/).
+
+Since QuestDB 10.0 the [Python client](/docs/connect/clients/python/) reads
+query results straight into a DataFrame with `to_pandas()` over QWP, with no
+SQLAlchemy or driver layer. Use it unless you need PGWire for compatibility
+reasons. See the [pandas guide](/docs/integrations/data-processing/pandas/)
+for both directions.
 
 :::
 
@@ -1193,9 +1198,12 @@ time-series data:
 - **psycopg3**: Excellent balance of features and performance, supports both sync and async operations
 - **psycopg2**: Mature and stable client with wide compatibility, but slower than asyncpg and psycopg3
 
-For most use cases, we recommend using asyncpg or psycopg3 for better performance. For data ingestion, consider using
-QuestDB's first-party clients with the InfluxDB Line Protocol (ILP) for maximum throughput.
+Among these, we recommend asyncpg or psycopg3 for better performance. For
+ingestion, and for DataFrame results, the
+[QuestDB Python client](/docs/connect/clients/python/) speaks QWP and is
+faster than any PGWire driver in both directions.
 
 ## Additional Resources
-- [Polars Integration with QuestDB](/docs/integrations/data-processing/polars)
-- [QuestDB Client for fast ingestion](/docs/connect/clients/python/)
+- [Pandas Integration with QuestDB](/docs/integrations/data-processing/pandas/)
+- [Polars Integration with QuestDB](/docs/integrations/data-processing/polars/)
+- [QuestDB Python client](/docs/connect/clients/python/)

--- a/documentation/integrations/data-processing/pandas.md
+++ b/documentation/integrations/data-processing/pandas.md
@@ -1,74 +1,199 @@
 ---
 title: Pandas
 description:
-  Guide for using Pandas with QuestDB via the official QuestDB Python client
-  library
+  Query QuestDB into pandas DataFrames and ingest DataFrames natively with the
+  QuestDB Python client over QWP.
 ---
 
 [Pandas](https://pandas.pydata.org/) is a fast, powerful, flexible, and
-easy-to-use open-source data analysis and manipulation tool, built on top of the
-Python programming language. The
-[QuestDB Python client](https://py-questdb-client.readthedocs.io/en/latest/index.html)
-provides native support for ingesting Pandas dataframes via the InfluxDB Line
-Protocol.
+easy-to-use open-source data analysis and manipulation tool built on top of
+Python. Since QuestDB 10.0 the
+[QuestDB Python client](/docs/connect/clients/python/) covers both directions
+natively over [QWP](/docs/connect/wire-protocols/qwp-ingress-websocket/):
+`db.dataframe()` ingests a whole frame column by column, and query results
+stream back as Arrow batches that materialize into a DataFrame with
+`to_pandas()`.
+
+Both paths are columnar end to end, so there is no SQLAlchemy, ODBC, or
+ConnectorX layer to install and no row-by-row conversion in the middle.
 
 ## Prerequisites
 
-- QuestDB must be running and accessible. Checkout the
+- QuestDB 10.0 or later, running and accessible. See the
   [quick start](/docs/getting-started/quick-start).
-- Python 3.8 or later
-- [Pandas](https://pandas.pydata.org/)
-- [pyarrow](https://pypi.org/project/pyarrow/)
-- [NumPy](https://numpy.org/)
+- Python 3.10 or later.
+- The client and pandas:
 
-## Querying vs. Ingestion
-This page focuses on ingestion, which is the process of inserting data into
-QuestDB. For querying data, see [PGWire client guide](/docs/connect/compatibility/pgwire/python/#integration-with-pandas).
+```bash
+python3 -m pip install -U questdb pandas
+```
 
-## Overview
+`pyarrow` is optional. `to_pandas()` and `iter_pandas()` work without it, and
+it is only needed if you also want `to_arrow()` or pyarrow-backed dtypes.
 
-The QuestDB Python client implements the `dataframe()` method to transform
-Pandas DataFrames into QuestDB-flavored InfluxDB Line Protocol messages.
+## Query into a DataFrame
 
-The following example shows how to insert data from a Pandas DataFrame to the
-`trades` table:
+`db.query()` returns a result that streams Arrow record batches from the
+server. Call `to_pandas()` to materialize the whole result:
 
 ```python
-from questdb.ingress import Sender, IngressError
+import questdb
 
-import sys
+with questdb.connect("ws::addr=localhost:9000;") as db:
+    with db.query(
+        "SELECT timestamp, symbol, price, amount FROM trades "
+        "WHERE timestamp IN '$now-1h..$now'"
+    ) as result:
+        df = result.to_pandas()
+
+print(df.head())
+```
+
+Bind values with `$1`..`$N` placeholders instead of interpolating them into
+the SQL string:
+
+```python
+df = db.query(
+    "SELECT * FROM trades WHERE symbol = $1 AND price > $2",
+    ["ETH-USDT", 2615.0],
+).to_pandas()
+```
+
+### Stream large results
+
+`to_pandas()` holds the complete result in memory. For results that do not fit
+comfortably, iterate batch by batch with `iter_pandas()` and reduce as you go:
+
+```python
+import questdb
+
+with questdb.connect("ws::addr=localhost:9000;") as db:
+    with db.query("SELECT price, amount FROM trades") as result:
+        notional = sum(
+            (chunk["price"] * chunk["amount"]).sum()
+            for chunk in result.iter_pandas()
+        )
+
+print(notional)
+```
+
+A result is single-use and must stay on the thread that created it. Use a
+`with` block, or call `close()`, so the connection returns to the pool.
+
+### Types and nulls
+
+`SYMBOL` columns arrive as a `Categorical` sharing one dictionary across
+batches, which keeps them compact. `INT` and `LONG` become plain `int32` /
+`int64` when the column has no nulls and nullable `Int32` / `Int64` with
+`pd.NA` when it does. QuestDB's sentinel values, such as `NaN` doubles and
+`INT64_MIN` longs, are decoded as nulls rather than leaking as magic numbers.
+
+`to_pandas(dtype_backend="pyarrow")` selects pyarrow-backed dtypes instead,
+matching the `pd.read_sql` convention. See
+[result types and nulls](/docs/connect/clients/python/#result-types-and-nulls)
+for the full mapping.
+
+## Ingest a DataFrame
+
+`db.dataframe()` publishes the frame in batches and blocks until the server
+acknowledges the last one:
+
+```python
 import pandas as pd
+import questdb
+
+df = pd.DataFrame({
+    "symbol": pd.Categorical(["ETH-USDT", "BTC-USDT"]),
+    "price": [2615.54, 65432.10],
+    "amount": [0.00044, 0.00120],
+    "timestamp": pd.to_datetime([
+        "2025-01-01T00:00:00Z",
+        "2025-01-01T00:00:01Z",
+    ]),
+})
+
+with questdb.connect("ws::addr=localhost:9000;") as db:
+    db.dataframe(df, table_name="trades", symbols=["symbol"], at="timestamp")
+```
+
+`symbols` defaults to `"auto"`, which maps categorical columns to `SYMBOL`;
+pass a list of column names to be explicit. `at` names the designated
+timestamp column, or takes a fixed timestamp shared by every row, or
+`questdb.ServerTimestamp` to let the server assign one.
+
+:::note
+
+Naive timestamps, both DataFrame columns and a scalar `at`, are interpreted as
+UTC, matching the numpy `datetime64` convention. Prefer timezone-aware values
+throughout.
+
+:::
+
+Columns of `float64` numpy arrays become `DOUBLE[]`, and `None`, `NaN`, and
+`pd.NA` are stored as SQL nulls. A frame the columnar path cannot express
+raises `UnsupportedDataFrameShapeError` listing the offending columns. See
+[DataFrame ingestion](/docs/connect/clients/python/#dataframe-ingestion) for
+batching, retries, and the full parameter set.
+
+## Legacy: ILP DataFrame ingestion
+
+:::warning
+
+Since QuestDB 10.0 the recommended way to move data between pandas and QuestDB
+is the native client shown above. The API below is documented for legacy
+reasons: it encodes the frame as InfluxDB Line Protocol text and only covers
+ingestion. Use it for existing code, or when talking to a server older than
+10.0.
+
+:::
+
+The 4.x-style standalone `Sender` ships in the same `questdb` package and
+implements `dataframe()` on top of ILP:
+
+```python
+import sys
+
+import pandas as pd
+from questdb import Sender, QuestDBError
 
 
-def example(host: str = 'localhost', port: int = 9009):
+def example(conf: str = "http::addr=localhost:9000;"):
     df = pd.DataFrame({
-            'pair': ['USDGBP', 'EURJPY'],
-            'traded_price': [0.83, 142.62],
-            'qty': [100, 400],
-            'limit_price': [0.84, None],
-            'timestamp': [
-                pd.Timestamp('2022-08-06 07:35:23.189062', tz='UTC'),
-                pd.Timestamp('2022-08-06 07:35:23.189062', tz='UTC')]})
+        "symbol": ["ETH-USDT", "BTC-USDT"],
+        "price": [2615.54, 65432.10],
+        "amount": [0.00044, 0.00120],
+        "timestamp": [
+            pd.Timestamp("2025-01-01 00:00:00", tz="UTC"),
+            pd.Timestamp("2025-01-01 00:00:01", tz="UTC"),
+        ],
+    })
     try:
-        with Sender(host, port) as sender:
+        with Sender.from_conf(conf) as sender:
             sender.dataframe(
                 df,
-                table_name='trades',  # Table name to insert into.
-                symbols=['pair'],  # Columns to be inserted as SYMBOL types.
-                at='timestamp')  # Column containing the designated timestamps.
+                table_name="trades",   # Table name to insert into.
+                symbols=["symbol"],    # Columns to insert as SYMBOL.
+                at="timestamp")        # Designated timestamp column.
 
-    except IngressError as e:
-        sys.stderr.write(f'Got error: {e}\n')
+    except QuestDBError as e:
+        sys.stderr.write(f"Got error: {e}\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     example()
 ```
 
+The `questdb.ingress` import path still works as a deprecated alias module,
+where `IngressError` remains an alias of `QuestDBError`. Importing from it
+raises a `DeprecationWarning`, so prefer `questdb` directly as shown above.
+The legacy API is documented on
+[ReadTheDocs](https://py-questdb-client.readthedocs.io/en/latest/), and the
+[5.0 migration guide](https://py-questdb-client.readthedocs.io/en/latest/migration.html)
+maps each 4.x call to its pooled equivalent.
+
 ## See also
 
-For detailed documentation, please see:
-
-- [`Sender.dataframe()`](https://py-questdb-client.readthedocs.io/en/latest/api.html#questdb.ingress.Sender.dataframe)
-- [`Buffer.dataframe()`](https://py-questdb-client.readthedocs.io/en/latest/api.html#questdb.ingress.Buffer.dataframe)
-- [Examples using `dataframe()`](https://py-questdb-client.readthedocs.io/en/latest/examples.html#data-frames)
+- [Python client](/docs/connect/clients/python/)
+- [Polars](/docs/integrations/data-processing/polars/)
+- [Connect string reference](/docs/connect/clients/connect-string/)
+- [Querying with PGWire drivers](/docs/connect/compatibility/pgwire/python/)

--- a/documentation/integrations/data-processing/polars.md
+++ b/documentation/integrations/data-processing/polars.md
@@ -1,43 +1,230 @@
 ---
 title: Polars
 description:
-  Guide for using Polars with QuestDB
+  Query QuestDB into Polars DataFrames and ingest them natively from Python
+  and Rust over QWP.
 ---
 
-[Polars](https://pola.rs/) is a fast DataFrame library implemented in Rust and
-Python. It is designed to process large datasets efficiently and is particularly
-well-suited for time-series data. Polars provides a DataFrame API similar to
-Pandas, but with a focus on performance and parallel execution.
+[Polars](https://pola.rs/) is a fast DataFrame library implemented in Rust
+with a Python API. It processes large datasets efficiently and is well suited
+to time-series work. Since QuestDB 10.0 the
+[Python](/docs/connect/clients/python/) and [Rust](/docs/connect/clients/rust/)
+clients both speak Polars natively over
+[QWP](/docs/connect/wire-protocols/qwp-ingress-websocket/), in both
+directions.
 
-## Overview
-
-ConnectorX is a Rust library that provides fast data transfer between Python
-and various databases, including QuestDB. It includes a connector for PostgreSQL
-which is compatible with QuestDB's PGWire protocol. This allows you to use
-ConnectorX to read data from QuestDB into a Polars DataFrame.
-
-:::caution
-
-**Note**: By default ConnectorX for PostgreSQL uses features not supported by QuestDB.
-If you instruct ConnectorX to use the Redshift protocol, it will work with QuestDB.
-
-:::
-
+QWP results arrive as Arrow record batches, which is Polars' own memory
+layout, so a query becomes a DataFrame with no row-by-row conversion.
+Ingestion sends the frame column by column over the same connection pool. No
+ConnectorX or PGWire driver is involved.
 
 ## Prerequisites
 
-- QuestDB must be running and accessible. Checkout the
+- QuestDB 10.0 or later, running and accessible. See the
   [quick start](/docs/getting-started/quick-start).
-- Python 3.8 or later
-- [Polars](https://pola.rs/)
-- [pyarrow](https://pypi.org/project/pyarrow/)
-- [ConnectorX](https://sfu-db.github.io/connector-x/intro.html)
+- For Python: version 3.10 or later, plus the client and Polars.
+- For Rust: `questdb-rs` with the Polars crate features enabled.
 
-```pip
+```bash
+python3 -m pip install -U questdb polars pyarrow
+```
+
+## Python
+
+### Query into a DataFrame
+
+`db.query()` streams Arrow batches from the server. `to_polars()` materializes
+the whole result:
+
+```python
+import questdb
+
+with questdb.connect("ws::addr=localhost:9000;") as db:
+    with db.query(
+        "SELECT timestamp, symbol, price, amount FROM trades "
+        "WHERE timestamp IN '$now-1h..$now'"
+    ) as result:
+        df = result.to_polars()
+
+print(df.head())
+```
+
+Bind values with `$1`..`$N` placeholders rather than interpolating them into
+the SQL string:
+
+```python
+df = db.query(
+    "SELECT * FROM trades WHERE symbol = $1 AND price > $2",
+    ["ETH-USDT", 2615.0],
+).to_polars()
+```
+
+`to_polars()` needs `pyarrow` installed. To skip that dependency, pass the
+result straight to the `pl.DataFrame` constructor, which reads it through the
+Arrow PyCapsule protocol:
+
+```python
+import polars as pl
+
+with db.query("SELECT * FROM trades LIMIT 1000") as result:
+    df = pl.DataFrame(result)
+```
+
+### Stream large results
+
+For results that do not fit comfortably in memory, iterate batch by batch with
+`iter_polars()`:
+
+```python
+import questdb
+
+with questdb.connect("ws::addr=localhost:9000;") as db:
+    with db.query("SELECT price, amount FROM trades") as result:
+        notional = sum(
+            (chunk["price"] * chunk["amount"]).sum()
+            for chunk in result.iter_polars()
+        )
+
+print(notional)
+```
+
+A result is single-use and must stay on the thread that created it. Use a
+`with` block, or call `close()`, so the connection returns to the pool.
+
+### Ingest a DataFrame
+
+`db.dataframe()` accepts Polars `DataFrame` and `LazyFrame` alongside pandas
+and pyarrow inputs. Each call publishes the frame in batches and blocks until
+the server acknowledges the last one:
+
+```python
+import polars as pl
+import questdb
+
+df = pl.DataFrame({
+    "symbol": ["ETH-USDT", "BTC-USDT"],
+    "price": [2615.54, 65432.10],
+    "amount": [0.00044, 0.00120],
+    "timestamp": [1735689600000000000, 1735689601000000000],
+}).with_columns(pl.col("timestamp").cast(pl.Datetime("ns", "UTC")))
+
+with questdb.connect("ws::addr=localhost:9000;") as db:
+    db.dataframe(df, table_name="trades", symbols=["symbol"], at="timestamp")
+```
+
+`symbols` takes a list of column names to store as `SYMBOL`, and `at` names
+the designated timestamp column. See
+[DataFrame ingestion](/docs/connect/clients/python/#dataframe-ingestion) for
+batching, null handling, and the full parameter set.
+
+## Rust
+
+### Crate features
+
+Polars support is gated behind optional crate features:
+
+```toml title="Cargo.toml"
+[dependencies]
+questdb-rs = { version = "7", features = ["polars"] }
+```
+
+The `polars` feature enables both `polars-ingress` and `polars-egress`. Enable
+only the one you need if your application goes in a single direction. See
+[crate features](/docs/connect/clients/rust/#crate-features) for the full
+list.
+
+### Query into a DataFrame
+
+Borrow a reader, prepare the SQL, bind values, and collect the cursor into a
+frame:
+
+```rust
+use questdb::QuestDb;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = QuestDb::connect("ws::addr=localhost:9000;")?;
+    let mut reader = db.borrow_reader()?;
+
+    let dataframe = reader
+        .prepare("SELECT timestamp, symbol, price FROM trades WHERE price > $1")
+        .bind_f64(2615.0)
+        .execute()?
+        .fetch_all_polars()?;
+
+    println!("{} rows", dataframe.height());
+    Ok(())
+}
+```
+
+`fetch_all_polars()` materializes the complete result. For large results,
+prefer `next_polars()` or `iter_polars()`, which yield one frame per batch.
+
+The `Cursor` returned by `execute()` borrows the reader, so keep the whole
+chain in one statement as above. Splitting it across a block that also owns
+the reader fails to compile.
+
+:::note
+
+The client depends on `polars` with default features off, and only within a
+version range. To use the returned frame in your own code, add `polars` as a
+direct dependency at a version inside that range, otherwise its `DataFrame` is
+a different type. Check the range in the client's `Cargo.toml`. Formatting a
+frame with `{}` also needs one of the polars `fmt` features, which the client
+does not enable.
+
+:::
+
+### Ingest a DataFrame
+
+`flush_polars_dataframe()` borrows a direct sender from the pool, publishes a
+commit boundary, waits for the requested ACK, and returns the connection:
+
+```rust
+use questdb::ingress::{
+    column_sender::ArrowColumnOverride,
+    polars::PolarsIngestOptions,
+    AckLevel,
+    ColumnName,
+};
+
+let overrides: [ArrowColumnOverride<'_>; 0] = [];
+let options = PolarsIngestOptions::new()
+    .max_rows(50_000)
+    .timestamp_column(ColumnName::new("timestamp")?)
+    .overrides(&overrides)
+    .ack_level(AckLevel::Ok);
+
+db.flush_polars_dataframe("trades", &dataframe, &options)?;
+```
+
+Omitting `timestamp_column` asks the server to assign timestamps, and
+`max_rows(0)` uses the default batch size. The call checkpoints the frame and
+automatically retries the uncommitted tail after a transient failover. Replay
+is at-least-once, so use [deduplication](/docs/concepts/deduplication/) when
+duplicates would be harmful. See
+[Arrow and Polars ingestion](/docs/connect/clients/rust/#arrow-and-polars-ingestion)
+for the Arrow equivalents.
+
+## Legacy: ConnectorX over PGWire
+
+:::warning
+
+Since QuestDB 10.0 the recommended way to move data between Polars and QuestDB
+is the native client support shown above. ConnectorX is documented here for
+legacy reasons only: it goes through PGWire, it reads but cannot ingest, and
+it needs a workaround to avoid PostgreSQL features QuestDB does not implement.
+
+:::
+
+[ConnectorX](https://sfu-db.github.io/connector-x/intro.html) is a Rust
+library for fast data transfer between Python and various databases. Its
+PostgreSQL connector works against QuestDB's PGWire endpoint, which lets
+`pl.read_database_uri()` read a query into a Polars DataFrame.
+
+```bash
 pip install polars pyarrow connectorx
 ```
 
-## Example
 ```python
 import polars as pl
 
@@ -49,14 +236,17 @@ print("Received DataFrame:")
 print(df)
 ```
 
-Note that the URL uses the `redshift` schema. This is important because
-it makes ConnectorX to avoid using features not supported by QuestDB.
+:::caution
 
-## Ingestion vs Querying
-This guides deals with querying data from QuestDB using Polars. For ingestion to QuestDB we recommend using the
-[QuestDB Python client](/docs/connect/clients/python/).
+The URI uses the `redshift` scheme, not `postgresql`. By default the
+PostgreSQL connector uses features QuestDB does not support; the Redshift
+scheme makes ConnectorX avoid them.
 
-## Additional Resources
-- [Integration with Pandas](/docs/integrations/data-processing/pandas/)
-- [QuestDB Client for fast ingestion](/docs/connect/clients/python/)
-- [Python clients guide](/docs/connect/compatibility/pgwire/python/)
+:::
+
+## See also
+
+- [Python client](/docs/connect/clients/python/)
+- [Rust client](/docs/connect/clients/rust/)
+- [Pandas](/docs/integrations/data-processing/pandas/)
+- [Connect string reference](/docs/connect/clients/connect-string/)

--- a/documentation/query/overview.md
+++ b/documentation/query/overview.md
@@ -2,9 +2,9 @@
 title: Query & SQL overview
 sidebar_label: Overview
 description:
-  "How to query QuestDB: run SQL in the Web Console, connect with PostgreSQL
-  clients, use the REST HTTP API, or read Parquet files, with time-series
-  extensions like SAMPLE BY."
+  "How to query QuestDB: run SQL in the Web Console, stream results with the
+  QWP client libraries, connect with PostgreSQL clients, use the REST HTTP API,
+  or read Parquet files, with time-series extensions like SAMPLE BY."
 ---
 
 import Screenshot from "@theme/Screenshot"
@@ -39,13 +39,15 @@ from"../partials/\_nodejs.exec.query.partial.mdx"
 import PythonExecQueryPartial from
 "../partials/\_python.exec.query.partial.mdx"
 
-You can query QuestDB in four ways:
+You can query QuestDB in five ways:
 
 1. Query via the
    [QuestDB Web Console](/docs/query/overview/#questdb-web-console)
-2. Query via [PostgreSQL](/docs/query/overview/#postgresql)
-3. Query via [REST HTTP API](/docs/query/overview/#rest-http-api)
-4. Query via [Apache Parquet](/docs/query/overview/#apache-parquet)
+2. Query via the
+   [QuestDB client libraries](/docs/query/overview/#questdb-client-libraries)
+3. Query via [PostgreSQL](/docs/query/overview/#postgresql)
+4. Query via [REST HTTP API](/docs/query/overview/#rest-http-api)
+5. Query via [Apache Parquet](/docs/query/overview/#apache-parquet)
 
 For efficient and clear querying, QuestDB provides SQL with enhanced time series
 extensions. This makes analyzing, downsampling, processing and reading time
@@ -54,8 +56,7 @@ series data an intuitive and flexible experience.
 Queries can be written into many applications using existing drivers and clients
 of the PostgreSQL or REST-ful ecosystems. However, querying is also leveraged
 heavily by third-party tools to provide visualizations, such as within
-[Grafana](/docs/integrations/visualization/grafana/), or for data analysis with dataframe
-libraries like [Polars](/docs/integrations/data-processing/polars/).
+[Grafana](/docs/integrations/visualization/grafana/).
 
 > Need to ingest data first? Check out our
 > [Ingestion overview](/docs/connect/overview/).
@@ -92,6 +93,32 @@ SAMPLE BY 15m;
 
 If you see _Demo this query_ on other snippets in this docs, they can be run
 against the demo instance.
+
+## QuestDB client libraries
+
+The official client libraries speak the QuestDB Wire Protocol (QWP), a binary
+protocol that carries both ingestion and query traffic over one connection and
+one configuration string. This is the fastest way to get data out of QuestDB
+from an application.
+
+Results stream rather than arriving in one block. The server sends batches as
+it produces them, so an application starts processing the head of a result
+while the tail is still being computed, and a result larger than memory never
+has to be materialized at all.
+
+Connections recover on their own. When a connection drops and replicas are
+available, the client reconnects and retries against another one without the
+application intervening. A query that fails over restarts from the beginning,
+which is transparent if you materialize the whole result.
+
+The Rust, C++, and Python clients hand back results as Arrow record batches.
+That is the native memory layout of
+[pandas](/docs/integrations/data-processing/pandas/),
+[Polars](/docs/integrations/data-processing/polars/), and DuckDB, so a query
+becomes a DataFrame with no row-by-row conversion in between.
+
+See the [Connect overview](/docs/connect/overview/) for the per-language
+guides and which clients ship QWP today.
 
 ## PostgreSQL
 


### PR DESCRIPTION
## Summary

Both data-processing pages predated QWP. They now lead with the native client
support that shipped in QuestDB 10.0, and keep the older approaches at the
bottom under a warning explaining they are there for legacy reasons.

**pandas** covers querying with `to_pandas()` / `iter_pandas()` and ingesting
with `db.dataframe()`. The legacy ILP `Sender.dataframe()` section keeps the
previous content, with two corrections: the old example used a
`Sender(host, port)` constructor removed back in the 2.x client, and it
imported from the deprecated `questdb.ingress` alias module, which now raises
a `DeprecationWarning`.

**Polars** covers Python and Rust. Python gets `to_polars()`, `iter_polars()`,
and the PyCapsule path that avoids a pyarrow dependency. Rust gets the
`polars-ingress` / `polars-egress` crate features, `fetch_all_polars()`, and
`flush_polars_dataframe()`. ConnectorX moves to the legacy section.

Two fixes outside those pages:

- `connect/clients/python.md` documented `polars.from_arrow(result)`, which
  warns that it will return a `Series` instead of a `DataFrame` in polars 2.0.
  Replaced with the `pl.DataFrame` constructor on both pages.
- `query/overview.md` listed four ways to query, none of them the QWP clients.
  Added a client libraries section ahead of PostgreSQL, and pointed the pandas
  note on the PGWire page at the native path.

Every snippet on both pages was executed against a local QuestDB 10.0.1 before
merge. The Python ones ran under `warnings.simplefilter("error")`; the Rust
ones were compiled and run against a `questdb-rs` 7.0.0 checkout.

Note that `questdb-rs` 7 is not yet on crates.io, where the latest is 6.1.0
with no reader or Polars features. The `version = "7"` pin matches what
`connect/clients/rust.md` already documents, so it will resolve once 7.0.0
ships.
