### PR TITLE
Remove the Parquet beta notice from the query overview

### DIFF
--- a/documentation/query/overview.md
+++ b/documentation/query/overview.md
@@ -389,18 +389,6 @@ run_query("UPDATE trades SET value = 9876 WHERE name = 'abc'")
 
 ## Apache Parquet
 
-:::info
-
-Apache Parquet support is in **beta**. It may not be fit for production use.
-
-Please let us know if you run into issues. Either:
-
-1. Email us at [support@questdb.io](mailto:support@questdb.io)
-2. Join our [public Slack](https://slack.questdb.com/)
-3. Post on our [Discourse community](https://community.questdb.com/)
-
-:::
-
 Parquet files can be read and thus queried by QuestDB.
 
 QuestDB is shipped with a demo Parquet file, `trades.parquet`, which can be


### PR DESCRIPTION
## Summary

Parquet is live, not beta. The query overview still carried an admonition saying support is in beta and "may not be fit for production use".

This was the last provisional-status claim about Parquet in the docs. The equivalent notice on the Parquet functions page went in #512; the concepts page and `ALTER TABLE ... SET PARQUET` never had one.