### PR TITLE
Add cookbook recipes for checking timestamp and column sort order

### DIFF
--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -30,6 +30,7 @@ This page tracks significant updates to the QuestDB documentation.
 - [ALTER TABLE REBASE WAL](/docs/query/sql/alter-table-rebase-wal/) - New reference page for rebuilding a suspended WAL table under a fresh sequencer, with its requirements and permission
 - [ALTER TABLE SET FORMAT](/docs/query/sql/alter-table-set-format/) - New reference page for switching a table's partition storage format between `NATIVE` and `PARQUET`
 - [QWP configuration](/docs/configuration/qwp/) - Server-side settings for the QWP ingestion (`/write/v4`) and query (`/read/v1`) endpoints
+- [Check timestamp order](/docs/cookbook/sql/time-series/check-timestamp-order/) and [Check column sort order](/docs/cookbook/sql/advanced/check-column-sort-order/) - Two cookbook recipes that detect unsorted data with `lag()`: whether a table, CSV import or external Parquet file is ordered by its timestamp, and whether one column is sorted with respect to another
 
 ### Reference
 
@@ -46,6 +47,7 @@ This page tracks significant updates to the QuestDB documentation.
 - [LIMIT](/docs/query/sql/limit/#null-bounds) - Documented null `LIMIT` bounds (supplied via bind variables) and their two-bound semantics
 - Added the [`cairo.sql.parquet.cache.memory.size`](/docs/configuration/cairo-engine/) configuration property (256 MB default), deprecating the slot-based `cairo.sql.parquet.frame.cache.capacity`
 - Documented [`cairo.root`](/docs/configuration/cairo-engine/) absolute-path behavior: the `conf`, `import`, `export`, `tmp`, and `.checkpoint` directories become siblings of the specified directory rather than children of the server root, so leave it at the default under Docker
+- [read_parquet](/docs/query/functions/parquet/#designated-timestamp) - Documented nominating a designated timestamp on a Parquet file with `TIMESTAMP()` (applied directly, on a sub-query, or on a CTE), and importing a file into a table with `INSERT INTO ... SELECT` or `CREATE TABLE AS`
 
 ### Updated
 
@@ -60,6 +62,10 @@ This page tracks significant updates to the QuestDB documentation.
 - [Time to live (TTL)](/docs/concepts/ttl/) - Documented TTL on materialized views, set with `CREATE MATERIALIZED VIEW ... TTL` or `ALTER MATERIALIZED VIEW ... SET TTL` and managed independently of the base table's TTL
 - [Result grid](/docs/getting-started/web-console/result-grid/) - Documented the Parquet and CSV download options in the web console result grid
 - [Docker Compose configuration](/docs/cookbook/operations/docker-compose-config/) - Reworked the volume-permission guidance and explained why `QDB_CAIRO_ROOT` should not be set in Docker
+- [QuestDB MCP server](/docs/getting-started/web-console/mcp-server/) - Renamed from "MCP connection" and reworked around when an agent actually needs an MCP server, with [AI coding agents](/docs/getting-started/ai-coding-agents/) gaining a four-option matrix covering the MCP server, the REST API, the agent skill, and the [QuestDB AI Assistant](/docs/getting-started/web-console/questdb-ai/)
+- [pandas](/docs/integrations/data-processing/pandas/) and [Polars](/docs/integrations/data-processing/polars/) - Rewritten around the native QWP clients, keeping the previous ILP and ConnectorX approaches as legacy; Polars now also covers the Rust `polars-ingress` and `polars-egress` crate features
+- [Python client](/docs/connect/clients/python/) - Documented N-dimensional `float64` numpy arrays landing in matching N-dimensional column types (other dtypes are rejected), and clarified Polars consumption: prefer `to_polars()`, with `polars.DataFrame(result)` reserved for pyarrow-free installs
+- [Query overview](/docs/query/overview/) - Added a client libraries section ahead of PostgreSQL, and removed the stale notice describing Parquet support as beta
 
 ## July 2026
 

--- a/documentation/concepts/designated-timestamp.md
+++ b/documentation/concepts/designated-timestamp.md
@@ -556,6 +556,14 @@ EXPLAIN SELECT * FROM trades WHERE timestamp IN '2024-01-15';
 Look for `Interval forward scan`—if you see `Async Filter` instead, the
 designated timestamp optimization isn't being used.
 
+**Check if a table without a designated timestamp is ordered:**
+
+A table with no designated timestamp carries no ordering guarantee. Since one
+cannot be added after the fact, test whether the timestamp column already
+ascends before migrating the data into a table that has one. See the
+[Check timestamp order](/docs/cookbook/sql/time-series/check-timestamp-order/)
+cookbook recipe.
+
 ## FAQ
 
 **Can I add a designated timestamp to an existing table?**

--- a/documentation/connect/compatibility/import-csv.md
+++ b/documentation/connect/compatibility/import-csv.md
@@ -262,6 +262,11 @@ the schema as required.
    ) TIMESTAMP (timestamp) partition by DAY;
    ```
 
+   To confirm the data you imported is ordered before recreating the table with
+   a designated timestamp, see the
+   [Check timestamp order](/docs/cookbook/sql/time-series/check-timestamp-order/)
+   cookbook recipe.
+
 9. Ready for import: Create an empty table using the final schema.
 
 ### Import CSV

--- a/documentation/cookbook/sql/advanced/check-column-sort-order.md
+++ b/documentation/cookbook/sql/advanced/check-column-sort-order.md
@@ -1,0 +1,65 @@
+---
+title: Check whether a column is sorted by another column
+sidebar_label: Check column sort order
+description: Use lag() with an explicit ORDER BY to test whether one column ever decreases as another column increases.
+---
+
+Sorting one column by another answers questions like whether large trades always print at better prices, or whether a cumulative field ever moves backwards against its key. This recipe reports where that relationship breaks.
+
+## Problem
+
+You want to know whether `price` only rises as `amount` grows, without assuming anything about the order the rows are stored in.
+
+## Solution
+
+Order the window by the column you are sorting against, compare each row's value with the previous one, and count the rows that go backwards:
+
+```questdb-sql demo title="Count rows where price falls as amount grows"
+SELECT count() AS out_of_order_rows
+FROM (
+  SELECT price AS current_price,
+         lag(price) OVER (ORDER BY amount) AS previous_price
+  FROM trades
+  WHERE symbol = 'BTC-USDT' AND timestamp IN '$today'
+)
+WHERE current_price < previous_price;
+```
+
+`ORDER BY amount` inside `OVER ()` is what makes this different from checking a column against the designated timestamp. Without it, `lag()` follows the table's scan order and answers a different question entirely, which is covered in [Check timestamp order](/docs/cookbook/sql/time-series/check-timestamp-order/).
+
+A result of `0` means `price` never decreases as `amount` increases. Any other number is the count of positions where it does.
+
+## Find the first row that breaks the order
+
+To locate the break rather than count breaks, number the rows and return the first violation:
+
+```questdb-sql demo title="Find the first row where price falls as amount grows"
+WITH column_and_prev AS (
+  SELECT row_number() OVER (ORDER BY amount) AS rownum,
+         amount,
+         price AS current_price,
+         lag(price) OVER (ORDER BY amount) AS previous_price
+  FROM trades
+  WHERE symbol = 'BTC-USDT' AND timestamp IN '$today'
+)
+SELECT rownum, amount, current_price, previous_price
+FROM column_and_prev
+WHERE current_price < previous_price
+ORDER BY rownum
+LIMIT 1;
+```
+
+`row_number()` must use the same `ORDER BY` as `lag()`. If it is left as `row_number() OVER ()` it numbers rows in scan order while `lag()` walks them in `amount` order, so the reported position belongs to a different sequence than the comparison.
+
+:::warning ORDER BY is required before LIMIT
+The rows leave the `WHERE` clause in scan order, not in `amount` order, so `LIMIT 1` on its own returns an arbitrary violation rather than the earliest one. `ORDER BY rownum` before `LIMIT 1` is what makes it the first.
+:::
+
+Filtering by a single symbol keeps the comparison meaningful. Across interleaved symbols the query reports breaks that are only an artefact of mixing instruments.
+
+:::info Related documentation
+- [Check timestamp order](/docs/cookbook/sql/time-series/check-timestamp-order/)
+- [Window functions reference](/docs/query/functions/window-functions/reference/)
+- [Window functions syntax](/docs/query/functions/window-functions/syntax/)
+- [ORDER BY keyword](/docs/query/sql/order-by/)
+:::

--- a/documentation/cookbook/sql/time-series/check-timestamp-order.md
+++ b/documentation/cookbook/sql/time-series/check-timestamp-order.md
@@ -1,0 +1,100 @@
+---
+title: Check whether data is sorted by timestamp
+sidebar_label: Check timestamp order
+description: Detect out-of-order timestamps in QuestDB tables, CSV imports and external Parquet files by comparing each row against the previous one with lag().
+---
+
+A table with a designated timestamp is always stored in ascending timestamp order. Data that arrives without a designated timestamp has no such guarantee: a CSV import, an external Parquet file or a non-WAL table can be in any order. This recipe checks the order before you rely on it, which avoids a `TIMESTAMP()` clause that fails at runtime or a time-series query that silently returns the wrong shape.
+
+## Problem
+
+You have a dataset whose ordering you cannot assume, and you need to know whether its timestamp column ascends before applying `TIMESTAMP()`, `SAMPLE BY` or `LATEST ON`.
+
+## Solution
+
+Compare each row's timestamp against the previous row with `lag()`, then count the rows that go backwards:
+
+```questdb-sql demo title="Count out-of-order timestamps"
+SELECT count() AS out_of_order_rows
+FROM (
+  SELECT timestamp AS current_ts, lag(timestamp) OVER () AS previous_ts
+  FROM trades
+  WHERE timestamp IN '$today'
+)
+WHERE current_ts < previous_ts;
+```
+
+A result of `0` means the data is sorted. The `trades` table has a designated timestamp, so it returns `0`. Run the same query against an unsorted source and the count is the number of positions where the order breaks.
+
+The comparison must be `current_ts < previous_ts`. Testing `current_ts > previous_ts` matches every normal increase instead of the violations, so it returns almost every row of a correctly sorted table.
+
+`lag()` returns `null` for the first row, and comparing against `null` is false, so the first row is never reported as a violation.
+
+:::note Order without ORDER BY
+`lag(timestamp) OVER ()` has no `ORDER BY`, so it follows the order in which QuestDB scans the table. That scan order is exactly what this recipe tests, which is why adding an `ORDER BY` here would defeat the check.
+:::
+
+## Find the first row that breaks the order
+
+Counting tells you how much data is out of order. To see where it breaks, number the rows and return the first violation:
+
+```questdb-sql demo title="Find the first out-of-order timestamp"
+WITH column_and_prev AS (
+  SELECT row_number() OVER () AS rownum,
+         timestamp AS current_ts,
+         lag(timestamp) OVER () AS previous_ts
+  FROM trades
+  WHERE timestamp IN '$today'
+)
+SELECT rownum, current_ts, previous_ts
+FROM column_and_prev
+WHERE current_ts < previous_ts
+LIMIT 1;
+```
+
+An empty result means the data is sorted. `row_number()` and `lag()` both follow scan order here, so `rownum` is the position of the offending row and `LIMIT 1` returns the earliest one.
+
+## Check another column against timestamp order
+
+The same shape answers whether a non-timestamp column ever decreases as time advances. Swap the timestamp for the column you care about:
+
+```questdb-sql demo title="Check whether price only rises over time"
+WITH column_and_prev AS (
+  SELECT row_number() OVER () AS rownum,
+         price AS current_price,
+         lag(price) OVER () AS previous_price
+  FROM trades
+  WHERE symbol = 'BTC-USDT' AND timestamp IN '$today'
+)
+SELECT rownum, current_price, previous_price
+FROM column_and_prev
+WHERE current_price < previous_price
+LIMIT 1;
+```
+
+This returns a row, because price falls as well as rises. Filtering by a single symbol matters: without it, the comparison runs across interleaved symbols and reports breaks that mean nothing.
+
+To compare a column against something other than the designated timestamp, see [Check whether a column is sorted by another column](/docs/cookbook/sql/advanced/check-column-sort-order/).
+
+## Check an external Parquet file
+
+`read_parquet()` returns no designated timestamp, so its order is unknown until you test it. Check the file before wrapping it in `TIMESTAMP()`:
+
+```questdb-sql demo title="Check timestamp order in a Parquet file"
+SELECT count() AS out_of_order_rows
+FROM (
+  SELECT timestamp AS current_ts, lag(timestamp) OVER () AS previous_ts
+  FROM read_parquet('trades.parquet')
+)
+WHERE current_ts < previous_ts;
+```
+
+If the count is `0`, you can apply `TIMESTAMP()` directly. If not, add an `ORDER BY` first.
+
+:::info Related documentation
+- [Force a designated timestamp](/docs/cookbook/sql/time-series/force-designated-timestamp/)
+- [Check whether a column is sorted by another column](/docs/cookbook/sql/advanced/check-column-sort-order/)
+- [Designated timestamp](/docs/concepts/designated-timestamp/)
+- [Window functions reference](/docs/query/functions/window-functions/reference/)
+- [Parquet functions](/docs/query/functions/parquet/)
+:::

--- a/documentation/cookbook/sql/time-series/force-designated-timestamp.md
+++ b/documentation/cookbook/sql/time-series/force-designated-timestamp.md
@@ -82,9 +82,12 @@ This query reads from a parquet file, applies ordering, forces the designated ti
 
 :::warning Order is Required
 The `TIMESTAMP()` keyword requires that the data is already sorted by the timestamp column. If the data is not in order, the query will fail. Always include `ORDER BY` before applying `TIMESTAMP()`.
+
+To test whether a source is already sorted, see [Check timestamp order](/docs/cookbook/sql/time-series/check-timestamp-order/).
 :::
 
 :::info Related Documentation
+- [Check timestamp order](/docs/cookbook/sql/time-series/check-timestamp-order/)
 - [Designated Timestamp concept](/docs/concepts/designated-timestamp/)
 - [TIMESTAMP keyword reference](/docs/query/sql/select/#timestamp)
 - [SAMPLE BY aggregation](/docs/query/sql/sample-by/)

--- a/documentation/query/functions/parquet.md
+++ b/documentation/query/functions/parquet.md
@@ -124,6 +124,10 @@ FROM (
 SAMPLE BY 1h;
 ```
 
+To find out whether a file needs that `ORDER BY` in the first place, see the
+[Check timestamp order](/docs/cookbook/sql/time-series/check-timestamp-order/)
+cookbook recipe.
+
 :::
 
 ### Importing a Parquet file into a table
@@ -250,5 +254,8 @@ Only a single file can be read per `read_parquet` call.
   to store a table's partitions as Parquet with `FORMAT PARQUET`.
 - [Designated timestamp](/docs/concepts/designated-timestamp/) explains what the
   designated timestamp is and what it enables.
+- [Check timestamp order](/docs/cookbook/sql/time-series/check-timestamp-order/)
+  is a cookbook recipe that tests whether a file is already sorted before you
+  nominate its timestamp.
 - [INSERT](/docs/query/sql/insert/) documents `INSERT INTO ... SELECT`,
   including the `ATOMIC` and `BATCH` keywords.

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -1014,6 +1014,7 @@ module.exports = {
                   items: [
                     "cookbook/sql/time-series/elapsed-time",
                     "cookbook/sql/time-series/force-designated-timestamp",
+                    "cookbook/sql/time-series/check-timestamp-order",
                     "cookbook/sql/time-series/latest-n-per-partition",
                     "cookbook/sql/time-series/session-windows",
                     "cookbook/sql/time-series/latest-activity-window",
@@ -1035,6 +1036,7 @@ module.exports = {
                   items: [
                     "cookbook/sql/advanced/rows-before-after-value-match",
                     "cookbook/sql/advanced/local-min-max",
+                    "cookbook/sql/advanced/check-column-sort-order",
                     "cookbook/sql/advanced/top-n-plus-others",
                     "cookbook/sql/advanced/pivot-with-others",
                     "cookbook/sql/advanced/unpivot-table",


### PR DESCRIPTION
## Summary

Two cookbook recipes for detecting unsorted data with `lag()`, plus cross-links from the pages where the question comes up.

**Check timestamp order** (Time-Series Patterns) covers whether a table, CSV import or external Parquet file is ordered by its timestamp: a count of out-of-order rows, a first-violation variant, a column-against-timestamp variant, and the `read_parquet()` case.

**Check column sort order** (Advanced SQL) covers whether one column is sorted with respect to another, using `lag(col) OVER (ORDER BY other)`.

Two details the queries depend on, both verified against demo.questdb.io:

- The ascending check must be `current < previous`. Testing `current > previous` matches every normal increase, so on a correctly sorted designated timestamp it returned 238,976 of 382,349 rows instead of 0.
- In the arbitrary-column recipe, `row_number()` must share the `ORDER BY` used by `lag()`, and the outer query needs `ORDER BY rownum` before `LIMIT 1`. Rows leave the filter in scan order, so a bare `LIMIT 1` returned the 20,832nd violation rather than the first.

Cross-links added where an unsorted source causes a real problem:

- `read_parquet` reference, in the `TIMESTAMP()` ordering warning and in Related documentation
- Designated timestamp concept, under "Verifying designated timestamp"
- CSV import, at the step where the target schema gains a designated timestamp
- Force a designated timestamp recipe, whose "Order is Required" warning the recipe answers

Every SQL example is tagged `demo` and was run against demo.questdb.io. Changelog updated for August 2026, which also picks up five user-facing commits merged since the last changelog entry.
