### PR TITLE
Move REST API to a first-level entry under Connect

### DIFF
--- a/documentation/connect/compatibility/rest-api.md
+++ b/documentation/connect/compatibility/rest-api.md
@@ -1,7 +1,7 @@
 ---
 slug: /connect/compatibility/rest-api
 title: REST API
-sidebar_label: REST HTTP API
+sidebar_label: Overview
 description: REST API reference documentation.
 ---
 

--- a/documentation/connect/overview.md
+++ b/documentation/connect/overview.md
@@ -4,8 +4,8 @@ title: Connect to QuestDB
 sidebar_label: Overview
 description:
   How to send data to QuestDB and run queries. Choose between native client
-  libraries, compatibility protocols (ILP, PGWire, REST), or the wire-protocol
-  specifications.
+  libraries, the REST API, compatibility protocols (ILP, PGWire), or the
+  wire-protocol specifications.
 ---
 
 import { Clients } from "../../src/components/Clients"
@@ -18,9 +18,12 @@ Pick the path that matches your environment.
 | Your situation                                                          | Use                                                              |
 | ----------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | Greenfield app — want the best throughput, durability, and feature set  | [**Client Libraries**](#client-libraries)                        |
-| Existing InfluxDB collectors, Telegraf, or Kafka / Flink pipelines      | [Compatibility → ILP](/docs/connect/compatibility/ilp/overview/)             |
+| An AI agent or MCP tooling driving the database                         | [Agents](/docs/connect/agents/)                                  |
+| Kafka, Flink, Redpanda, or Telegraf pipelines                           | [Message brokers](/docs/integrations/overview/#data-ingestion-and-streaming) |
+| HTTP scripts, ad-hoc `curl`, or CSV imports                             | [REST API](#rest-api)                                            |
+| Existing InfluxDB collectors, or anything that already emits ILP        | [Compatibility → ILP](/docs/connect/compatibility/ilp/overview/)             |
 | Postgres-shaped data layer, BI tools, ORMs                              | [Compatibility → PGWire](/docs/connect/compatibility/pgwire/overview/)           |
-| HTTP scripts, ad-hoc `curl`, or CSV imports                             | [Compatibility → REST API](/docs/connect/compatibility/rest-api/)                |
+| Embedding QuestDB inside a JVM application                              | [Java (embedded)](/docs/connect/java-embedded/)                  |
 | Building a new QuestDB client library (QWP spec)                        | [Wire Protocols](/docs/connect/wire-protocols/overview/)                      |
 
 ## Client Libraries
@@ -65,6 +68,20 @@ Pick a language:
 
 <Clients showProtocol="QWP" />
 
+## REST API
+
+HTTP / JSON endpoints on port `9000`, understood by any off-the-shelf HTTP
+client. Reach for it when you want a `curl` one-liner, a shell script, a health
+check, or a bulk file load without pulling in a client library. It is not
+superseded by QWP.
+
+- **[REST API](/docs/connect/compatibility/rest-api/)**: `/exec` runs SQL and
+  returns JSON, `/imp` uploads CSV, `/exp` exports results as CSV or Parquet.
+- **[CSV import](/docs/connect/compatibility/import-csv/)**: bulk loading a CSV
+  file, over HTTP or with `COPY`.
+- **[Parquet export](/docs/concepts/parquet/#export)**: writing query results to
+  Parquet.
+
 ## Compatibility protocols
 
 Use these if you have existing tooling that speaks them, or if a native client
@@ -76,8 +93,6 @@ library isn't a fit for your environment.
 - **[PostgreSQL Wire Protocol (PGWire)](/docs/connect/compatibility/pgwire/overview/)** — query
   QuestDB from any Postgres-compatible driver (psycopg, JDBC, pgx, …), BI
   tools (Tableau, Grafana, Metabase), and ORMs.
-- **[REST API](/docs/connect/compatibility/rest-api/)** — HTTP / JSON endpoints for ad-hoc
-  queries, scripting, and bulk [CSV import](/docs/connect/compatibility/import-csv/).
 
 These remain fully supported. They are grouped as *compatibility* because they
 predate QWP and exist primarily to integrate with tooling that already speaks

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -114,6 +114,20 @@ module.exports = {
         },
         {
           type: "category",
+          label: "REST API",
+          collapsed: true,
+          items: [
+            "connect/compatibility/rest-api",
+            "connect/compatibility/import-csv",
+            {
+              label: "Parquet Export",
+              type: "link",
+              href: "/docs/concepts/parquet/#export",
+            },
+          ],
+        },
+        {
+          type: "category",
           label: "Compatibility Protocols",
           items: [
             {
@@ -197,20 +211,6 @@ module.exports = {
                   id: "connect/compatibility/pgwire/c-and-cpp",
                   type: "doc",
                   label: "C/C++",
-                },
-              ],
-            },
-            {
-              type: "category",
-              label: "REST API",
-              collapsed: true,
-              items: [
-                "connect/compatibility/rest-api",
-                "connect/compatibility/import-csv",
-                {
-                  label: "Parquet Export",
-                  type: "link",
-                  href: "/docs/concepts/parquet/#export",
                 },
               ],
             },


### PR DESCRIPTION
## Summary

The REST API sat under `Connect > Compatibility Protocols` next to ILP and PGWire. It does not belong in that category: it is not superseded by QWP and is still the simplest way to run ad-hoc queries, script against the database, and bulk load CSV.

- Promoted `REST API` to a first-level category under Connect, placed after Message Brokers.
- Renamed the entry page's `sidebar_label` to `Overview`, matching ILP and PGWire. Slugs are unchanged, so no redirects are needed.
- Connect overview: REST API now has its own section rather than a bullet under compatibility protocols.
- Connect overview routing table now covers every first-level Connect entry, adding Agents, message brokers, and Java embedded. Kafka and Flink users are routed to the connector listing instead of the raw ILP page.

Discussed in [Slack](https://questdb-tech.slack.com/archives/C06JXAF3VM2/p1787052353914599).