### PR TITLE
fix(ci): stop label events cancelling in-flight preview builds

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,9 +17,14 @@ on:
 permissions:
   contents: read
 
+# Successive pushes supersede each other, but a label event must never cancel an
+# in-flight build. Concurrency is evaluated before the job's `if`, so a label
+# other than "preview" (one attached as the PR is opened, say) would otherwise
+# cancel the build started by the "opened" event and then skip itself, leaving
+# the PR with no preview and no artifact for the deploy half to pick up.
 concurrency:
   group: preview-build-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.action != 'labeled' }}
 
 jobs:
   pr-preview:


### PR DESCRIPTION
## Summary

Opening a PR with any label attached silently loses its preview.

`gh pr create --label ...`, or adding a label immediately after opening, fires a `labeled` event alongside `opened`. Both match the workflow trigger, and concurrency is evaluated *before* the job's `if`, so the `labeled` run cancels the build started by `opened` and then skips itself, because the `if` only admits label events for the `preview` label. The PR ends up with no build, no artifact, and the deploy half correctly does nothing.

Seen on #519, opened with a `DO NOT MERGE` label:

| run | outcome |
| --- | --- |
| `32251682731` | cancelled, the `opened` build |
| `32251689951` | skipped, the `labeled` event |

Fix: label events no longer cancel an in-flight build.

```yaml
cancel-in-progress: ${{ github.event.action != 'labeled' }}
```

Successive pushes still supersede each other, which is the case the setting was there for.
