### PR TITLE
docs: update MCP server references for the mcp-server-questdb rename

### DIFF
--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -66,6 +66,7 @@ This page tracks significant updates to the QuestDB documentation.
 - [pandas](/docs/integrations/data-processing/pandas/) and [Polars](/docs/integrations/data-processing/polars/) - Rewritten around the native QWP clients, keeping the previous ILP and ConnectorX approaches as legacy; Polars now also covers the Rust `polars-ingress` and `polars-egress` crate features
 - [Python client](/docs/connect/clients/python/) - Documented N-dimensional `float64` numpy arrays landing in matching N-dimensional column types (other dtypes are rejected), and clarified Polars consumption: prefer `to_polars()`, with `polars.DataFrame(result)` reserved for pyarrow-free installs
 - [Query overview](/docs/query/overview/) - Added a client libraries section ahead of PostgreSQL, and removed the stale notice describing Parquet support as beta
+- [QuestDB MCP server](/docs/getting-started/web-console/mcp-server/) - Updated for the renamed MCP server: the npm package is now `@questdb/mcp-server-questdb` (previously `@questdb/mcp-bridge`) and the repository is now `questdb/mcp-server-questdb`, also reflected in [AI coding agents](/docs/getting-started/ai-coding-agents/)
 
 ## July 2026
 

--- a/documentation/getting-started/ai-coding-agents.mdx
+++ b/documentation/getting-started/ai-coding-agents.mdx
@@ -34,8 +34,8 @@ benchmarking.
 
 ## QuestDB MCP server
 
-The official <a href="https://github.com/questdb/mcp-bridge" target="_blank">QuestDB
-MCP server</a> (`@questdb/mcp-bridge`) connects coding
+The official <a href="https://github.com/questdb/mcp-server-questdb" target="_blank">QuestDB
+MCP server</a> (`@questdb/mcp-server-questdb`) connects coding
 agents to a running
 [Web Console](/docs/getting-started/web-console/overview/). Every action
 executes in the browser through your already-authenticated console session, and

--- a/documentation/getting-started/web-console/mcp-server.md
+++ b/documentation/getting-started/web-console/mcp-server.md
@@ -16,7 +16,7 @@ import Tabs from "@theme/Tabs"
 
 import TabItem from "@theme/TabItem"
 
-The official <a href="https://github.com/questdb/mcp-bridge" target="_blank">QuestDB MCP server</a> (`@questdb/mcp-bridge`) connects coding agents to a running Web Console. The agent gets tools to explore your database schema, run SQL, and build [notebooks](/docs/getting-started/web-console/notebooks/overview) with charts and live dashboards. Every action executes in the browser through your already-authenticated console session: the server runs locally on your machine, listens on loopback only, and never handles credentials.
+The official <a href="https://github.com/questdb/mcp-server-questdb" target="_blank">QuestDB MCP server</a> (`@questdb/mcp-server-questdb`) connects coding agents to a running Web Console. The agent gets tools to explore your database schema, run SQL, and build [notebooks](/docs/getting-started/web-console/notebooks/overview) with charts and live dashboards. Every action executes in the browser through your already-authenticated console session: the server runs locally on your machine, listens on loopback only, and never handles credentials.
 
 The setup wizard detects and configures Claude Code, Codex, Cursor, OpenCode, and Gemini CLI. Any other MCP client works with the manual configuration.
 
@@ -49,7 +49,7 @@ One command configures the MCP server for every supported agent on your machine;
 Copy the setup command from the MCP status pill and run it in your terminal:
 
 ```shell
-npx @questdb/mcp-bridge@<expected-version> setup
+npx @questdb/mcp-server-questdb@<expected-version> setup
 ```
 
 The wizard detects your installed coding agents, lets you pick which ones to configure, and writes the server into each agent's MCP config, pinned to that version.
@@ -65,7 +65,7 @@ Add the server to your MCP client's config file by hand, pinning the version sho
   "mcpServers": {
     "questdb": {
       "command": "npx",
-      "args": ["-y", "@questdb/mcp-bridge@<expected-version>"]
+      "args": ["-y", "@questdb/mcp-server-questdb@<expected-version>"]
     }
   }
 }
@@ -193,7 +193,7 @@ click the notification when it is ready:
 
 ## Next steps
 
-- The MCP server is open source at <a href="https://github.com/questdb/mcp-bridge" target="_blank">github.com/questdb/mcp-bridge</a>: issues and contributions welcome
+- The MCP server is open source at <a href="https://github.com/questdb/mcp-server-questdb" target="_blank">github.com/questdb/mcp-server-questdb</a>: issues and contributions welcome
 - [AI coding agents](/docs/getting-started/ai-coding-agents/) covers agent skills and REST API access
 - [Live dashboards](/docs/getting-started/web-console/notebooks/live-dashboards) shows how to build the same dashboards by hand
 - [Web Console overview](/docs/getting-started/web-console/overview/) tours the console surfaces


### PR DESCRIPTION
## Summary

The MCP server repository was renamed to `questdb/mcp-server-questdb` and the npm package to `@questdb/mcp-server-questdb` (previously `@questdb/mcp-bridge`). This updates the documentation accordingly:

- **MCP server page**: repo links, the `npx` setup command, and the manual `.mcp.json` configuration now use the new package and repository names
- **AI coding agents page**: repo link and package name updated
- **Changelog**: new entry under August 2026 recording the rename; existing entries are left untouched as historical record

Deliberately unchanged: the `MCP_BRIDGE_PORT` environment variable and the `/tmp/questdb-mcp-bridge/…` default log path — verified against the renamed repo's README, which still uses both (and notes `@questdb/mcp-bridge` remains published as a legacy alias).

`static/llms.txt` is auto-generated, so it is not touched here and will pick up the new wording on regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)