### PR TITLE
docs: drop the redundant WAL keyword from CREATE TABLE examples

### DIFF
--- a/.claude/skills/questdb-docs-writer/SKILL.md
+++ b/.claude/skills/questdb-docs-writer/SKILL.md
@@ -325,6 +325,39 @@ WHERE timestamp IN today()
 WHERE timestamp > dateadd('h', -1, now())
 ```
 
+### Omit the WAL keyword
+
+`WAL` has long been the default for partitioned tables, so `CREATE TABLE`
+examples must not pass it explicitly. Spelling it out adds noise and implies
+the keyword is required.
+
+```sql
+-- Preferred
+CREATE TABLE trades (
+  timestamp TIMESTAMP,
+  symbol SYMBOL,
+  price DOUBLE
+) TIMESTAMP(timestamp) PARTITION BY DAY;
+
+-- Avoid
+) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+```
+
+This holds for every clause combination. `FORMAT PARQUET`, `STORAGE POLICY`,
+`DEDUP UPSERT KEYS`, `TTL`, and posting indexes all produce a WAL table
+without the keyword.
+
+Keep `WAL` only where it is the subject of the example:
+
+- The [write-ahead log](/docs/concepts/write-ahead-log/) page, which teaches
+  the keyword and shows the plain form first
+- Syntax blocks presenting the grammar, such as `[BYPASS WAL | WAL]`
+- Examples that deliberately contrast a WAL table against a `BYPASS WAL` one
+- `BYPASS WAL` itself, which is never redundant
+
+`SHOW CREATE TABLE` no longer emits `WAL` either, so any documented output
+sample must match what the server actually returns.
+
 ### Finance-friendly examples
 
 - Use realistic table and column names from the finance domain
@@ -759,6 +792,8 @@ When reviewing a documentation page, check:
 - [ ] Examples use demo datasets where possible (`fx_trades`, `core_price`, etc.)
 - [ ] Demoable queries marked with `demo` tag
 - [ ] TICK syntax used for date filtering (`'$today'`, `'$now-1h..$now'`)
+- [ ] No redundant `WAL` keyword in `CREATE TABLE` examples, and any
+      `SHOW CREATE TABLE` output sample matches what the server emits
 - [ ] Both `!=` and `<>` shown where inequality is documented
 - [ ] No horizontal scrolling in code blocks
 - [ ] Links use correct paths (`/docs/query/...` not `/docs/reference/...`)

--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -12,7 +12,12 @@ This page tracks significant updates to the QuestDB documentation.
 
 ### Releases
 
+- [10.0.1](https://questdb.com/release-notes/) - Released August 24, 2026
 - [10.0.0](https://questdb.com/release-notes/) - Released August 6, 2026
+
+### QuestDB Enterprise Releases
+
+- [4.0.0](https://questdb.com/release-notes/) - Released August 25, 2026
 
 ### New
 
@@ -35,6 +40,7 @@ This page tracks significant updates to the QuestDB documentation.
 - [ALTER TABLE SET FORMAT](/docs/query/sql/alter-table-set-format/) - New reference page for switching a table's partition storage format between `NATIVE` and `PARQUET`
 - [QWP configuration](/docs/configuration/qwp/) - Server-side settings for the QWP ingestion (`/write/v4`) and query (`/read/v1`) endpoints
 - [Check timestamp order](/docs/cookbook/sql/time-series/check-timestamp-order/) and [Check column sort order](/docs/cookbook/sql/advanced/check-column-sort-order/) - Two cookbook recipes that detect unsorted data with `lag()`: whether a table, CSV import or external Parquet file is ordered by its timestamp, and whether one column is sorted with respect to another
+- [Kubernetes Operator](/docs/enterprise-kubernetes-operator/) - New manual for running QuestDB Enterprise clusters on Kubernetes, covering [installation](/docs/enterprise-kubernetes-operator/installation/), getting started on [AWS](/docs/enterprise-kubernetes-operator/getting-started/aws/) and [Azure](/docs/enterprise-kubernetes-operator/getting-started/azure/), [configuration](/docs/enterprise-kubernetes-operator/configuration/), [day-to-day operations](/docs/enterprise-kubernetes-operator/operations/operator/), [high availability](/docs/enterprise-kubernetes-operator/high-availability/), [known limitations](/docs/enterprise-kubernetes-operator/known-limitations/), and the full [API reference](/docs/enterprise-kubernetes-operator/reference/api/)
 
 ### Reference
 
@@ -78,6 +84,9 @@ This page tracks significant updates to the QuestDB documentation.
 - [Python client](/docs/connect/clients/python/) - Documented N-dimensional `float64` numpy arrays landing in matching N-dimensional column types (other dtypes are rejected), and clarified Polars consumption: prefer `to_polars()`, with `polars.DataFrame(result)` reserved for pyarrow-free installs
 - [Query overview](/docs/query/overview/) - Added a client libraries section ahead of PostgreSQL, and removed the stale notice describing Parquet support as beta
 - [QuestDB MCP server](/docs/getting-started/web-console/mcp-server/) - Updated for the renamed MCP server: the npm package is now `@questdb/mcp-server-questdb` (previously `@questdb/mcp-bridge`) and the repository is now `questdb/mcp-server-questdb`, also reflected in [AI coding agents](/docs/getting-started/ai-coding-agents/)
+- [.NET client](/docs/connect/clients/dotnet/) - Documented the optional `net-questdb-client-zstd` package for `QueryClient` egress compression: the fail-fast `ConfigError` raised when `compression=zstd` is requested without it, `compression=auto` degrading silently to raw, and the trimmed and Native AOT reflection caveat. The beta notice now refers to 4.0.0
+- [systemd deployment](/docs/deployment/systemd/) - `ExecStart` now depends on which archive you extracted rather than on CPU architecture, because only the `rt-` archive bundles Java while the no-JRE archive runs on system Java and needs `-p /opt/questdb/questdb.jar`. A new Startup failures section maps both common boot errors to their cause and fix
+- [CREATE TABLE](/docs/query/sql/create-table/#write-ahead-log-wal-settings) - Dropped the redundant `WAL` keyword from `CREATE TABLE` examples across the documentation. Partitioned tables have been WAL-enabled by default for a long time, and [SHOW CREATE TABLE](/docs/query/sql/show/#show-create-table) no longer emits the keyword either, so the documented output now matches what the server returns
 
 ## July 2026
 

--- a/documentation/concepts/deduplication.md
+++ b/documentation/concepts/deduplication.md
@@ -40,7 +40,7 @@ CREATE TABLE prices (
     ts TIMESTAMP,
     ticker SYMBOL,
     price DOUBLE
-) TIMESTAMP(ts) PARTITION BY DAY WAL
+) TIMESTAMP(ts) PARTITION BY DAY
 DEDUP UPSERT KEYS(ts, ticker);
 ```
 
@@ -96,7 +96,7 @@ CREATE TABLE prices (
     ts TIMESTAMP,
     ticker SYMBOL,
     price DOUBLE
-) TIMESTAMP(ts) PARTITION BY DAY WAL
+) TIMESTAMP(ts) PARTITION BY DAY
 DEDUP UPSERT KEYS(ts, ticker);
 ```
 

--- a/documentation/concepts/deep-dive/posting-index.md
+++ b/documentation/concepts/deep-dive/posting-index.md
@@ -44,7 +44,7 @@ CREATE TABLE trades (
     exchange SYMBOL,
     price DOUBLE,
     quantity DOUBLE
-) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+) TIMESTAMP(timestamp) PARTITION BY DAY;
 ```
 
 Out-of-line syntax (index defined separately):
@@ -57,7 +57,7 @@ CREATE TABLE trades (
     price DOUBLE,
     quantity DOUBLE
 ), INDEX(symbol TYPE POSTING)
-TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+TIMESTAMP(timestamp) PARTITION BY DAY;
 ```
 
 ### With covering columns (INCLUDE)
@@ -69,7 +69,7 @@ CREATE TABLE trades (
     exchange SYMBOL,
     price DOUBLE,
     quantity DOUBLE
-) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+) TIMESTAMP(timestamp) PARTITION BY DAY;
 ```
 
 The `INCLUDE` clause specifies which columns are stored in the index sidecar
@@ -150,15 +150,15 @@ benchmarking.
 ```questdb-sql
 -- Default adaptive encoding (recommended for most workloads)
 CREATE TABLE t1 (ts TIMESTAMP, s SYMBOL INDEX TYPE POSTING)
-    TIMESTAMP(ts) PARTITION BY DAY WAL;
+    TIMESTAMP(ts) PARTITION BY DAY;
 
 -- Force Elias-Fano only (benchmarking)
 CREATE TABLE t2 (ts TIMESTAMP, s SYMBOL INDEX TYPE POSTING EF)
-    TIMESTAMP(ts) PARTITION BY DAY WAL;
+    TIMESTAMP(ts) PARTITION BY DAY;
 
 -- Force delta + Frame-of-Reference only (benchmarking)
 CREATE TABLE t3 (ts TIMESTAMP, s SYMBOL INDEX TYPE POSTING DELTA)
-    TIMESTAMP(ts) PARTITION BY DAY WAL;
+    TIMESTAMP(ts) PARTITION BY DAY;
 ```
 
 ## Covering index
@@ -225,7 +225,7 @@ CREATE TABLE trades (
     -- other columns not needed in hot queries
     raw_data VARCHAR,
     metadata VARCHAR
-) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+) TIMESTAMP(timestamp) PARTITION BY DAY;
 ```
 
 :::tip

--- a/documentation/concepts/deep-dive/sql-extensions.md
+++ b/documentation/concepts/deep-dive/sql-extensions.md
@@ -285,7 +285,7 @@ CREATE TABLE trades (
     symbol SYMBOL INDEX TYPE POSTING INCLUDE (price, amount),
     price DOUBLE,
     amount DOUBLE
-) TIMESTAMP(ts) PARTITION BY DAY WAL;
+) TIMESTAMP(ts) PARTITION BY DAY;
 ```
 
 ## PIVOT

--- a/documentation/concepts/delivery-semantics.md
+++ b/documentation/concepts/delivery-semantics.md
@@ -93,7 +93,7 @@ CREATE TABLE trades (
     side SYMBOL,
     price DOUBLE,
     qty DOUBLE
-) TIMESTAMP(ts) PARTITION BY DAY WAL
+) TIMESTAMP(ts) PARTITION BY DAY
 DEDUP UPSERT KEYS(ts, symbol, side);
 ```
 

--- a/documentation/concepts/live-views.md
+++ b/documentation/concepts/live-views.md
@@ -53,7 +53,7 @@ CREATE TABLE trades (
   price DOUBLE,
   amount DOUBLE,
   timestamp TIMESTAMP
-) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+) TIMESTAMP(timestamp) PARTITION BY DAY;
 ```
 
 Create a live view that keeps a 300-row moving average of price per symbol:

--- a/documentation/concepts/parquet.md
+++ b/documentation/concepts/parquet.md
@@ -35,8 +35,7 @@ CREATE TABLE trades (
   amount DOUBLE
 ) TIMESTAMP(timestamp)
 PARTITION BY DAY
-FORMAT PARQUET
-WAL;
+FORMAT PARQUET;
 ```
 
 See [CREATE TABLE — Partition format](/docs/query/sql/create-table/#partition-format)

--- a/documentation/concepts/storage-policy.md
+++ b/documentation/concepts/storage-policy.md
@@ -161,8 +161,7 @@ CREATE TABLE trades (
     symbol SYMBOL,
     price DOUBLE
 ) TIMESTAMP(ts) PARTITION BY DAY
-    STORAGE POLICY(TO PARQUET 3d, DROP LOCAL 1M)
-    WAL;
+    STORAGE POLICY(TO PARQUET 3d, DROP LOCAL 1M);
 ```
 
 ### On existing tables
@@ -327,8 +326,7 @@ CREATE TABLE trades (
     symbol SYMBOL,
     price DOUBLE
 ) TIMESTAMP(ts) PARTITION BY DAY
-    STORAGE POLICY(TO PARQUET 3d, DROP LOCAL 1M)
-    WAL;
+    STORAGE POLICY(TO PARQUET 3d, DROP LOCAL 1M);
 ```
 
 ```questdb-sql title="2. Verify via the system view"

--- a/documentation/concepts/symbol.md
+++ b/documentation/concepts/symbol.md
@@ -134,7 +134,7 @@ CREATE TABLE trades (
     timestamp TIMESTAMP,
     symbol SYMBOL INDEX TYPE POSTING INCLUDE (price),
     price DOUBLE
-) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+) TIMESTAMP(timestamp) PARTITION BY DAY;
 ```
 
 Or add an index later:

--- a/documentation/connect/clients/dotnet.md
+++ b/documentation/connect/clients/dotnet.md
@@ -1219,7 +1219,7 @@ metadata is then available on the reader as `RowsAffected` and `OpType`:
 await using var reader = await client.ExecuteReaderAsync(
     "CREATE TABLE trades ("
     + "ts TIMESTAMP, symbol SYMBOL, price DOUBLE, amount LONG"
-    + ") TIMESTAMP(ts) PARTITION BY DAY WAL");
+    + ") TIMESTAMP(ts) PARTITION BY DAY");
 
 while (await reader.ReadBatchAsync()) { /* no batches for DDL/DML */ }
 

--- a/documentation/connect/clients/go.md
+++ b/documentation/connect/clients/go.md
@@ -115,7 +115,7 @@ func main() {
 	if _, err := query.Exec(ctx,
 		"CREATE TABLE IF NOT EXISTS trades "+
 			"(ts TIMESTAMP, symbol SYMBOL, side SYMBOL, price DOUBLE, amount DOUBLE) "+
-			"TIMESTAMP(ts) PARTITION BY DAY WAL"); err != nil {
+			"TIMESTAMP(ts) PARTITION BY DAY"); err != nil {
 		panic(err)
 	}
 
@@ -991,7 +991,7 @@ Non-SELECT statements run through `Exec`, which returns an `ExecResult`:
 ```go
 res, err := query.Exec(ctx,
 	"CREATE TABLE trades (ts TIMESTAMP, symbol SYMBOL, side SYMBOL, "+
-		"price DOUBLE, amount DOUBLE) TIMESTAMP(ts) PARTITION BY DAY WAL")
+		"price DOUBLE, amount DOUBLE) TIMESTAMP(ts) PARTITION BY DAY")
 if err != nil {
 	return err
 }
@@ -1620,7 +1620,7 @@ func main() {
 	if _, err := query.Exec(ctx,
 		"CREATE TABLE IF NOT EXISTS trades "+
 			"(ts TIMESTAMP, symbol SYMBOL, side SYMBOL, price DOUBLE, amount DOUBLE) "+
-			"TIMESTAMP(ts) PARTITION BY DAY WAL "+
+			"TIMESTAMP(ts) PARTITION BY DAY "+
 			"DEDUP UPSERT KEYS(ts, symbol, side)"); err != nil {
 		panic(err)
 	}

--- a/documentation/connect/clients/java.md
+++ b/documentation/connect/clients/java.md
@@ -1160,7 +1160,7 @@ callback:
 try (Query q = db.borrowQuery()) {
     q.sql("CREATE TABLE trades ("
           + "ts TIMESTAMP, symbol SYMBOL, side SYMBOL, price DOUBLE, amount DOUBLE"
-          + ") TIMESTAMP(ts) PARTITION BY DAY WAL")
+          + ") TIMESTAMP(ts) PARTITION BY DAY")
      .handler(new QwpColumnBatchHandler() {
          @Override public void onBatch(QwpColumnBatch batch) {}
          @Override public void onEnd(long totalRows) {}

--- a/documentation/connect/clients/python.md
+++ b/documentation/connect/clients/python.md
@@ -605,7 +605,7 @@ with questdb.connect("ws::addr=localhost:9000;") as db:
         "CREATE TABLE IF NOT EXISTS trades ("
         "  timestamp TIMESTAMP, symbol SYMBOL,"
         "  price DOUBLE, amount DOUBLE"
-        ") TIMESTAMP(timestamp) PARTITION BY DAY WAL"
+        ") TIMESTAMP(timestamp) PARTITION BY DAY"
     )
 ```
 

--- a/documentation/connect/compatibility/ilp/overview.md
+++ b/documentation/connect/compatibility/ilp/overview.md
@@ -465,7 +465,7 @@ CREATE TABLE IF NOT EXISTS 'trades' (
   price DOUBLE,
   amount DOUBLE,
   my_ts TIMESTAMP
-) timestamp (my_ts) PARTITION BY DAY WAL;
+) timestamp (my_ts) PARTITION BY DAY;
 ```
 
 You can use the `CREATE TABLE IF NOT EXISTS` construct to make sure the table is

--- a/documentation/connect/compatibility/pgwire/java.md
+++ b/documentation/connect/compatibility/pgwire/java.md
@@ -254,7 +254,7 @@ public class ArrayInsert {
                         bid DOUBLE PRECISION[][],
                         ask DOUBLE PRECISION[][],
                         timestamp TIMESTAMP
-                    ) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+                    ) TIMESTAMP(timestamp) PARTITION BY DAY;
                     """;
                 stmt.execute(createTableSQL);
                 System.out.println("Table 'l3_order_book' is ready.");

--- a/documentation/connect/compatibility/pgwire/python.md
+++ b/documentation/connect/compatibility/pgwire/python.md
@@ -425,10 +425,10 @@ async def batch_insert_l3_order_book_arrays():
     await conn.execute("""
                        CREATE TABLE IF NOT EXISTS l3_order_book
                        (
-                           bid DOUBLE [][],
-                           ask DOUBLE [][],
+                           bid DOUBLE[][],
+                           ask DOUBLE[][],
                            timestamp TIMESTAMP
-                       ) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+                       ) TIMESTAMP(timestamp) PARTITION BY DAY;
                        """)
 
     # Prepare a list of L3 order book snapshots for batch insertion
@@ -739,10 +739,10 @@ async def batch_insert_l3_order_book_arrays():
             await cur.execute("""
                               CREATE TABLE IF NOT EXISTS l3_order_book
                               (
-                                  bid DOUBLE [][],
-                                  ask DOUBLE [][],
+                                  bid DOUBLE[][],
+                                  ask DOUBLE[][],
                                   timestamp TIMESTAMP
-                              ) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+                              ) TIMESTAMP(timestamp) PARTITION BY DAY;
                               """)
             print("Table 'l3_order_book' is ready.")
 

--- a/documentation/cookbook/sql/advanced/sankey-funnel.md
+++ b/documentation/cookbook/sql/advanced/sankey-funnel.md
@@ -20,7 +20,7 @@ CREATE TABLE events (
     pathname SYMBOL,
     timestamp TIMESTAMP,
     metric_name SYMBOL
-) TIMESTAMP(timestamp) PARTITION BY MONTH WAL;
+) TIMESTAMP(timestamp) PARTITION BY MONTH;
 ```
 
 ## Solution: Session window functions

--- a/documentation/getting-started/enterprise-quick-start.md
+++ b/documentation/getting-started/enterprise-quick-start.md
@@ -531,8 +531,7 @@ CREATE TABLE trades (
     symbol SYMBOL,
     price DOUBLE
 ) TIMESTAMP(ts) PARTITION BY DAY
-  STORAGE POLICY(TO PARQUET 3d, DROP LOCAL 1M)
-  WAL;
+  STORAGE POLICY(TO PARQUET 3d, DROP LOCAL 1M);
 ```
 
 Or attach a policy to an existing table:

--- a/documentation/query/sql/create-live-view.md
+++ b/documentation/query/sql/create-live-view.md
@@ -249,7 +249,7 @@ CREATE TABLE trades (
   price DOUBLE,
   amount DOUBLE,
   timestamp TIMESTAMP
-) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+) TIMESTAMP(timestamp) PARTITION BY DAY;
 ```
 
 ```questdb-sql title="Fully specified live view"

--- a/documentation/query/sql/create-table.md
+++ b/documentation/query/sql/create-table.md
@@ -221,8 +221,7 @@ CREATE TABLE trades (
   amount DOUBLE
 ) TIMESTAMP(timestamp)
 PARTITION BY DAY
-FORMAT PARQUET
-WAL;
+FORMAT PARQUET;
 ```
 
 `FORMAT` accepts one of:
@@ -336,8 +335,7 @@ CREATE TABLE trades (
   amount DOUBLE
 ) TIMESTAMP(timestamp)
 PARTITION BY DAY
-STORAGE POLICY(TO PARQUET 3d, DROP LOCAL 1M)
-WAL;
+STORAGE POLICY(TO PARQUET 3d, DROP LOCAL 1M);
 ```
 
 A storage policy supports up to four settings: `TO PARQUET`, `TO REMOTE`,
@@ -748,7 +746,7 @@ CREATE TABLE trades (
   symbol SYMBOL INDEX TYPE POSTING,
   price DOUBLE,
   amount DOUBLE
-) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+) TIMESTAMP(timestamp) PARTITION BY DAY;
 
 -- Out-of-line syntax
 CREATE TABLE trades (
@@ -757,7 +755,7 @@ CREATE TABLE trades (
   price DOUBLE,
   amount DOUBLE
 ), INDEX(symbol TYPE POSTING)
-TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+TIMESTAMP(timestamp) PARTITION BY DAY;
 ```
 
 ### Posting index with covering columns (INCLUDE)
@@ -774,7 +772,7 @@ CREATE TABLE trades (
   exchange SYMBOL,
   price DOUBLE,
   amount DOUBLE
-) TIMESTAMP(timestamp) PARTITION BY DAY WAL;
+) TIMESTAMP(timestamp) PARTITION BY DAY;
 ```
 
 The designated timestamp column is automatically included — you do not need
@@ -796,8 +794,7 @@ table.
 :::tip
 
 Posting indexes (with or without `INCLUDE`) work on both WAL and `BYPASS WAL`
-tables. The examples above use `WAL` because it is the recommended default,
-but `BYPASS WAL` tables can declare posting indexes in exactly the same way.
+tables.
 
 :::
 

--- a/documentation/query/sql/sample-by.md
+++ b/documentation/query/sql/sample-by.md
@@ -285,7 +285,7 @@ Consider a table `trades` with the following data spanning three calendar days:
 CREATE TABLE trades (
   ts TIMESTAMP,
   price DOUBLE
-) TIMESTAMP(ts) PARTITION BY DAY WAL;
+) TIMESTAMP(ts) PARTITION BY DAY;
 
 INSERT INTO trades (ts, price) VALUES
   ('2021-05-31T23:10:00.000000Z', 100.5),

--- a/documentation/query/sql/show.md
+++ b/documentation/query/sql/show.md
@@ -235,7 +235,7 @@ SHOW CREATE TABLE trades;
 
 | ddl                                                                                                                                                                                                                                      |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CREATE TABLE trades (symbol SYMBOL CAPACITY 256 CACHE, side SYMBOL CAPACITY 256 CACHE, price DOUBLE, amount DOUBLE, timestamp TIMESTAMP) timestamp(timestamp) PARTITION BY DAY WAL WITH maxUncommittedRows=500000, o3MaxLag=600000000us; |
+| CREATE TABLE trades (symbol SYMBOL CAPACITY 256 CACHE, side SYMBOL CAPACITY 256 CACHE, price DOUBLE, amount DOUBLE, timestamp TIMESTAMP) timestamp(timestamp) PARTITION BY DAY WITH maxUncommittedRows=500000, o3MaxLag=600000000us; |
 
 This is printed with formatting, so when pasted into a text editor that support formatting characters, you will see:
 
@@ -246,7 +246,7 @@ CREATE TABLE trades (
 	price DOUBLE,
 	amount DOUBLE,
 	timestamp TIMESTAMP
-) timestamp(timestamp) PARTITION BY DAY WAL
+) timestamp(timestamp) PARTITION BY DAY
 WITH maxUncommittedRows=500000, o3MaxLag=600000000us;
 ```
 
@@ -265,7 +265,7 @@ CREATE TABLE trades (
 	price DOUBLE,
 	amount DOUBLE,
 	timestamp TIMESTAMP
-) timestamp(timestamp) PARTITION BY DAY WAL
+) timestamp(timestamp) PARTITION BY DAY
 WITH maxUncommittedRows=500000, o3MaxLag=600000000us;
 ```
 
@@ -299,7 +299,7 @@ CREATE TABLE 'sensor_data' (
     ts TIMESTAMP,
     value DOUBLE
 ) timestamp(ts) PARTITION BY DAY
-STORAGE POLICY(TO PARQUET 3 DAYS, DROP LOCAL 1 MONTH) WAL;
+STORAGE POLICY(TO PARQUET 3 DAYS, DROP LOCAL 1 MONTH);
 ```
 
 Stages that are not configured on the policy are omitted from the clause. Only
@@ -320,7 +320,7 @@ CREATE TABLE trades (
 	price DOUBLE,
 	amount DOUBLE,
 	timestamp TIMESTAMP
-) timestamp(timestamp) PARTITION BY DAY WAL
+) timestamp(timestamp) PARTITION BY DAY
 WITH maxUncommittedRows=500000, o3MaxLag=600000000us
 OWNED BY 'admin';
 ```

--- a/documentation/schema-design-essentials.md
+++ b/documentation/schema-design-essentials.md
@@ -98,7 +98,7 @@ CREATE TABLE trades (
     ts TIMESTAMP,
     symbol SYMBOL INDEX,
     price DOUBLE
-) TIMESTAMP(ts) PARTITION BY DAY WAL;
+) TIMESTAMP(ts) PARTITION BY DAY;
 
 -- Posting index with covering columns — best for read-heavy, selective queries
 CREATE TABLE trades (
@@ -106,7 +106,7 @@ CREATE TABLE trades (
     symbol SYMBOL INDEX TYPE POSTING INCLUDE (price),
     price DOUBLE,
     raw_data VARCHAR  -- not in INCLUDE, read from column files
-) TIMESTAMP(ts) PARTITION BY DAY WAL;
+) TIMESTAMP(ts) PARTITION BY DAY;
 -- The designated timestamp (ts) is automatically included in the covering index.
 ```
 


### PR DESCRIPTION
## Summary

`WAL` has been the default for partitioned tables for a long time, but 30 `CREATE TABLE` examples across 21 pages still passed it explicitly. Removed it.

Kept where it is deliberate: the Write-Ahead Log concept page, which teaches the keyword, the `[BYPASS WAL | WAL]` syntax blocks, and the embedded Java page, where `WAL` and `BYPASS WAL` are contrasted on purpose.

Also in here:

- `SHOW CREATE TABLE` output samples no longer show `WAL`, matching what the server returns today.
- Two array column declarations in the PGWire Python page used `DOUBLE [][]`, which fails to parse. Removed the space.
- August changelog entry, plus the release lines and Kubernetes Operator manual that were missing from it.

Every changed statement was executed against a local instance and confirmed to still produce a WAL table, including the `FORMAT PARQUET`, `STORAGE POLICY`, `DEDUP` and posting index combinations.
