### PR TITLE
docs: document the optional count in SAMPLE BY

### DIFF
--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -65,6 +65,7 @@ This page tracks significant updates to the QuestDB documentation.
 - Added the [`cairo.sql.parquet.cache.memory.size`](/docs/configuration/cairo-engine/) configuration property (256 MB default), deprecating the slot-based `cairo.sql.parquet.frame.cache.capacity`
 - Documented [`cairo.root`](/docs/configuration/cairo-engine/) absolute-path behavior: the `conf`, `import`, `export`, `tmp`, and `.checkpoint` directories become siblings of the specified directory rather than children of the server root, so leave it at the default under Docker
 - [read_parquet](/docs/query/functions/parquet/#designated-timestamp) - Documented nominating a designated timestamp on a Parquet file with `TIMESTAMP()` (applied directly, on a sub-query, or on a CTE), and importing a file into a table with `INSERT INTO ... SELECT` or `CREATE TABLE AS`
+- [SAMPLE BY](/docs/query/sql/sample-by/#sample-units) - Documented that the count is optional and defaults to `1`, so `SAMPLE BY h` is the same as `SAMPLE BY 1h`, and that it must be a positive integer written with no space before the unit
 
 ### Updated
 

--- a/documentation/query/sql/sample-by.md
+++ b/documentation/query/sql/sample-by.md
@@ -14,7 +14,7 @@ Requires a [designated timestamp](/docs/concepts/designated-timestamp/) column.
 SELECT columns, aggregate_functions
 FROM table
 [WHERE conditions]
-SAMPLE BY <n><unit>
+SAMPLE BY [count]unit
     [FROM timestamp TO timestamp]
     [FILL(fill_option)]
     [ALIGN TO CALENDAR [TIME ZONE tz] [WITH OFFSET offset] | ALIGN TO FIRST OBSERVATION]
@@ -22,7 +22,7 @@ SAMPLE BY <n><unit>
 
 ### Key clauses
 
-- **`SAMPLE BY <n><unit>`**: Groups rows into time buckets (e.g., `1h`, `5m`, `1d`)
+- **`SAMPLE BY [count]unit`**: Groups rows into time buckets (e.g., `1h`, `5m`, `1d`). The count is optional and defaults to `1`, so `h` means the same as `1h`
 - **`FROM ... TO`**: Defines explicit time boundaries for filling missing intervals
 - **`FILL(option)`**: Specifies how to handle missing time buckets (`NONE`, `NULL`, `PREV`, `LINEAR`, or constant)
 - **`ALIGN TO CALENDAR`**: Aligns buckets to calendar boundaries (default). Supports `TIME ZONE` and `WITH OFFSET`
@@ -30,11 +30,15 @@ SAMPLE BY <n><unit>
 
 ## Sample units
 
-The size of sampled groups are specified with the following syntax:
+The size of sampled groups is specified as a count and a unit:
 
 ```questdb-sql
-SAMPLE BY n{units}
+SAMPLE BY [count]unit
 ```
+
+The count is optional and defaults to `1`, so `SAMPLE BY h` and `SAMPLE BY 1h`
+return identical results. When supplied it must be a positive integer written
+immediately before the unit, with no space between the two.
 
 Where the unit for sampled groups may be one of the following:
 
@@ -58,6 +62,14 @@ trades per hour:
 SELECT ts, count()
 FROM trades
 SAMPLE BY 1h;
+```
+
+Written without the count, this is the same query:
+
+```questdb-sql
+SELECT ts, count()
+FROM trades
+SAMPLE BY h;
 ```
 
 ## Fill options


### PR DESCRIPTION
## Summary

`SAMPLE BY` accepts a bare unit, where the count defaults to `1`, so `SAMPLE BY h` and `SAMPLE BY 1h` are the same query. That has never been documented. Prompted by questdb/questdb#7391, which fixed `w` as the last unit that did not accept the bare form.

The syntax now reads `SAMPLE BY [count]unit`, with the default spelled out, plus the two constraints worth knowing: the count must be a positive integer, and no space is allowed before the unit.

Also renames the syntax placeholder. It was `n`, which is the nanosecond unit listed in the table immediately below, and making the count optional would have made that collision easier to trip over.

Verified against a local instance: all ten units accept the bare form and return result sets identical to the explicit `1<unit>` form.
