### PR TITLE
docs: make the documentation discoverable to AI agents

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,6 +90,32 @@ const config = {
         }
       },
     }),
+    // Agent-facing directive pointing at the documentation index. Agents that
+    // fetch HTML have no other signal that llms.txt exists, or that every page
+    // can be had as markdown. Visually hidden, so it costs nothing on screen.
+    () => ({
+      name: "agent-llms-directive",
+      injectHtmlTags() {
+        return {
+          preBodyTags: [
+            {
+              tagName: "div",
+              attributes: {
+                "data-agent-directive": "llms-txt",
+                style:
+                  "position:absolute;width:1px;height:1px;padding:0;margin:-1px;" +
+                  "overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0",
+              },
+              innerHTML:
+                'For AI agents: the complete documentation index is at ' +
+                '<a href="https://questdb.com/docs/llms.txt">llms.txt</a>. ' +
+                'Every page is also available as markdown by appending .md to ' +
+                'its URL, or by sending an Accept: text/markdown request header.',
+            },
+          ],
+        }
+      },
+    }),
     require.resolve("./plugins/fetch-latest-release/index"),
     require.resolve("./plugins/fetch-java-client-release/index"),
     require.resolve("./plugins/fetch-repo/index"),

--- a/plugins/raw-markdown/index.js
+++ b/plugins/raw-markdown/index.js
@@ -9,6 +9,32 @@ const {
   normalizeNewLines,
 } = require("./convert-components")
 
+// Directive pointing agents at the full documentation index. An agent that
+// fetches a single page has no other signal that an index exists, or that any
+// page can be had as markdown.
+const AGENT_DIRECTIVE =
+  "> **For AI agents:** the complete documentation index is at " +
+  "[llms.txt](https://questdb.com/docs/llms.txt). Every page is available as " +
+  "markdown by appending `.md` to its URL, or by sending an " +
+  "`Accept: text/markdown` request header."
+
+/**
+ * Inserts the agent directive immediately after the page's H1, so it sits near
+ * the top without displacing the title.
+ * @param {string} content - Markdown that already starts with its H1
+ * @returns {string} Markdown with the directive inserted
+ */
+function prependAgentDirective(content) {
+  const lines = content.split("\n")
+
+  if (lines[0] && lines[0].startsWith("# ")) {
+    const rest = lines.slice(1).join("\n").replace(/^\n+/, "")
+    return `${lines[0]}\n\n${AGENT_DIRECTIVE}\n\n${rest}`
+  }
+
+  return `${AGENT_DIRECTIVE}\n\n${content}`
+}
+
 module.exports = () => ({
   name: "raw-markdown",
   async postBuild({ outDir, plugins }) {
@@ -60,6 +86,10 @@ module.exports = () => ({
 
           // Prepend title and description from frontmatter
           let processedContent = prependFrontmatter(markdownContent, frontmatter, true)
+
+          // Agent-facing directive: point at the full documentation index so an
+          // agent that lands on a single page can find its way to the rest.
+          processedContent = prependAgentDirective(processedContent)
 
           // Process partial component imports
           const currentFileRelativeDir = path.dirname(relativePath)

--- a/scripts/generate-llms-files.js
+++ b/scripts/generate-llms-files.js
@@ -152,6 +152,14 @@ function generateLlmsFiles() {
 
   let llmsOutput = `# QuestDB Documentation
 
+> QuestDB is a high-performance time-series database with SQL. This index links
+> every documentation page as markdown, covering SQL reference and time-series
+> extensions such as SAMPLE BY, ASOF JOIN and LATEST ON, ingestion over the
+> QuestDB Wire Protocol, InfluxDB Line Protocol and PostgreSQL wire protocol,
+> deployment, configuration and operations. Every page is also available as
+> markdown by appending .md to its URL, or by sending an
+> \`Accept: text/markdown\` request header.
+
 ## Getting Started
 
 `

--- a/static/_headers
+++ b/static/_headers
@@ -19,13 +19,17 @@
   Access-Control-Allow-Methods: GET, OPTIONS
   Cache-Control: public, max-age=60
 
-# Cache JavaScript, CSS, SVG, TXT, and WebP files for a year
+# Cache fingerprinted assets for a year
 /*.js
-  Cache-Control: public, max-age=31536000
-/*.txt
   Cache-Control: public, max-age=31536000
 /*.webp
   Cache-Control: public, max-age=31536000
+
+# llms.txt and robots.txt are regenerated on every deploy, so they must
+# revalidate rather than be cached like immutable assets. A year-long TTL here
+# means agents keep reading a stale documentation index long after it changes.
+/*.txt
+  Cache-Control: public, max-age=60
 
 # Cache images in the /images/ folder for 2 days
 /images/*


### PR DESCRIPTION
## Summary

Fixes the Content Discoverability failures that [afdocs](https://afdocs.dev/) reported against questdb.com/docs, plus one cache header.

**Agent directive on every page.** An agent that lands on a single docs page has no signal that an index exists, or that any page can be fetched as markdown. Both are now stated explicitly:

- HTML: a visually-hidden `div` injected via `preBodyTags`, using the clip-rect pattern, so it costs nothing on screen
- Markdown: a blockquote inserted after the H1, so the title still comes first

This is the change Emre suggested in the thread. It is the highest-value of the three, because it reaches agents that fetch HTML by default rather than only those sending `Accept: text/markdown`.

**llms.txt structure.** The validator wants four things: an H1, a `>` blockquote summary, more than one heading, and markdown links. We had three. The blockquote is now there, and mentions both ways to get markdown.

**Cache headers.** `static/_headers` cached every `.txt` for a year under a rule meant for fingerprinted assets. The docs build contains exactly two `.txt` files, `llms.txt` and `robots.txt`, and both are regenerated on every deploy, so agents were being served an index up to a year stale. Now `max-age=60`, matching what `.html` and `.md` already use, and comfortably inside the check's 3600 threshold.

## Not addressed

`llms-txt-size` stays a warning. At 74.5 KB it sits in the 50-100K "consider splitting" band. Clearing it means nested llms.txt files with a root index under 50 KB, which is a structural change to how the index is generated and is better decided on its own.

## Verifying

Local verification is limited, since afdocs samples from llms.txt and those links are absolute production URLs. Against the deploy preview:

```
npx afdocs check <preview-url> --canonical-origin https://questdb.com \
  --max-concurrency 2 --request-delay 400
```

The throttling flags are not optional. questdb.com returns HTTP 403 under sustained load, afdocs classifies 403 as `auth-required`, and an unthrottled run scores the site 39 instead of 85. That is a separate problem from this PR, and worth fixing on the Netlify side, since it affects real agents and crawlers too, not just this tool.
