### PR TITLE
version: "current" is the Docusaurus version tag that the DocSearch c…

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -262,6 +262,9 @@ const config = {
       indexName: "questdb",
       searchPagePath: false,
       contextualSearch: false,
+      searchParameters: {
+        optionalFilters: ["version:current"],
+      },
     },
   },
   presets: [


### PR DESCRIPTION
version: "current" is the Docusaurus version tag that the DocSearch crawler stamps on every record it extracts from /docs/. It is absent on three kinds of records in the same index: blog posts, the hand-built release-notes records, and the synthetic code/table chunk records the crawler emits for large pages. So this one parameter expresses "prefer documentation over blog, and prefer real doc sections over code fragments" without a hard section tier — a blog post still wins when it is a strictly better word match, but it no longer wins just because its title prefix-matches the query (e.g. mode → "…storage model" posts).

It is paired with an index-settings change (custom ranking moved back to the tiebreaker position, distinct on url_without_anchor). This parameter has to live in the site config rather than in Algolia because optionalFilters is a per-query parameter, not an index setting. Deploying it before the index change is a no-op; deploying it after completes the fix.