### PR TITLE
docs: remove obsolete Operator v0.2.1 tag history

### DIFF
--- a/documentation/enterprise-kubernetes-operator/releases.md
+++ b/documentation/enterprise-kubernetes-operator/releases.md
@@ -45,9 +45,6 @@ helm install questdb-operator oci://ghcr.io/questdb/charts/questdb-operator \
 
 ## [0.2.1] - 2026-09-02
 
-An earlier source-only `v0.2.1` tag was deleted before any image, chart, or GitHub
-Release was published. This is the official 0.2.1 release.
-
 ### Added
 
 - Verified Secret-backed PGWire TLS for new clusters.


### PR DESCRIPTION
## Summary

- remove the obsolete source-tag history note from the public Operator v0.2.1 release page
- leave the published v0.2.1 release contents unchanged

This is an intentional post-release correction to a generated page. The published tag remains unchanged; the canonical changelog on `main` is corrected in questdb/questdb-enterprise-operator#294.

## Testing

- `yarn build`
