### PR TITLE
docs: document the symbol capacity auto-scaling keys

### DIFF
--- a/documentation/configuration/cairo-engine.md
+++ b/documentation/configuration/cairo-engine.md
@@ -281,6 +281,32 @@ Estimated partition size on disk. This is one of the conditions that triggers
 
 ## Symbol and indexing
 
+### cairo.auto.scale.symbol.capacity
+
+- **Default**: `true`
+- **Reloadable**: no
+
+Enables symbol capacity auto-scaling, which resizes the symbol table data
+structures as the number of symbols in a table grows. Keeping these structures
+optimally sized is what makes
+[symbol capacity automatic](/docs/concepts/symbol/) from QuestDB 9.0.0 onwards,
+and it is the recommended setting. Disable it only to work around a problem
+with auto-scaling itself.
+
+Changing this setting requires a database restart.
+
+### cairo.auto.scale.symbol.capacity.threshold
+
+- **Default**: `0.8`
+- **Reloadable**: no
+
+Fraction of the symbol table capacity at which the table is resized. With the
+default of `0.8`, the symbol table is resized as soon as the symbol count goes
+over 80% of the current capacity.
+
+Must be a positive, non-zero, finite number. Any other value stops the server
+from starting.
+
 ### cairo.default.symbol.cache.flag
 
 - **Default**: `true`


### PR DESCRIPTION
`cairo.auto.scale.symbol.capacity` and `cairo.auto.scale.symbol.capacity.threshold` are not on the Cairo engine configuration page, even though they control the automatic symbol capacity that `concepts/symbol` already describes as the behaviour from 9.0.0 onwards. This adds both to the **Symbol and indexing** section.

Values taken from the core rather than from the sample config:

- `PropServerConfiguration.java:1077` reads the flag with `getBoolean(..., true)`, so the default is `true`. That matches @nwoolmer's note on #274 that questdb/questdb#6352 enabled it by default, and it is the opposite of what the commented-out line in the shipped `server.conf` suggests (`#cairo.auto.scale.symbol.capacity=false`), which is what made the reporter read it as a contradiction.
- `PropServerConfiguration.java:1078` reads the threshold with `getDouble(..., "0.8")`, and the next line rejects a non-positive or non-finite value with a `ServerConfigurationException`, so an invalid value stops startup instead of falling back to the default.
- Neither key appears in the `dynamicProps` set in `DynamicPropServerConfiguration.java`, so neither is reloadable and both need a restart. The comment above that same line in the default `server.conf` says the opposite ("Database restart is NOT required when this setting is changed"), so I documented what the code does. Happy to drop the restart sentence if the config comment is the intended contract and the set is what is out of date.

Descriptions follow the javadoc on `CairoConfiguration`.

This covers the second of the three points in #274. The first (`query.timeout`) went in with #483; the third (`line.tcp.auth.db.path` missing from the generated config) is a core concern rather than a docs one.
