### PR TITLE
docs: document the UUID byte order in the Rust and C/C++ clients

### DIFF
--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -8,6 +8,21 @@ description: Recent updates and improvements to the QuestDB documentation.
 
 This page tracks significant updates to the QuestDB documentation.
 
+## September 2026
+
+### QuestDB Enterprise Releases
+
+- [4.0.1](https://questdb.com/release-notes/) - Released September 1, 2026
+
+### New
+
+- [Migrate QuestDB onto the Kubernetes Operator](/docs/enterprise-kubernetes-operator/getting-started/migrate/) - Move an existing Enterprise deployment onto the Operator with a replica-first cutover: restore the source backup, consume replication WAL, then promote after a controlled source drain
+
+### Updated
+
+- [Kubernetes Operator](/docs/enterprise-kubernetes-operator/) - Refreshed for Operator 0.2.1 across installation, configuration, high availability, backup and restore, known limitations, troubleshooting, and the generated [API reference](/docs/enterprise-kubernetes-operator/reference/api/)
+- [Rust](/docs/connect/clients/rust/) and [C and C++](/docs/connect/clients/c-and-cpp/) clients - Documented the UUID byte order, which was previously unstated. `Buffer::column_uuid` takes `(lo, hi)` where `hi` is the most significant half, matching `java.util.UUID`, and the chunk setter takes the 16 bytes in canonical RFC-4122 order
+
 ## August 2026
 
 ### Releases

--- a/documentation/connect/clients/c-and-cpp.md
+++ b/documentation/connect/clients/c-and-cpp.md
@@ -776,7 +776,7 @@ See `qwp_sender.h` for the exact signatures. Complete list:
 | `column_bool` | LSB-first packed bitmap | `BOOLEAN` |
 | `column_ts` + `qwp_ts_unit` (`_micros` / `_nanos`) | int64 since epoch | `TIMESTAMP` / `TIMESTAMP_NS` |
 | `column_date` | int64 millis since epoch | `DATE` |
-| `column_uuid` | 16 bytes | `UUID` |
+| `column_uuid` | 16 bytes, canonical RFC-4122 order | `UUID` |
 | `column_long256` | 32 bytes (4 LE limbs) | `LONG256` |
 | `column_ipv4` | uint32 | `IPV4` |
 | `column_str` | Arrow Utf8 offsets + bytes | `VARCHAR` |

--- a/documentation/connect/clients/rust.md
+++ b/documentation/connect/clients/rust.md
@@ -251,6 +251,22 @@ an existing nullable column.
 | `DOUBLE[]` | `column_arr`, `column_arr_opt` |
 | `TIMESTAMP`, `TIMESTAMP_NS` | `column_ts`, `column_ts_opt` |
 
+`column_uuid` takes `(name, lo, hi)`, where `hi` is the most significant 64
+bits of the UUID and `lo` the least significant. That is the same split as
+`java.util.UUID`, but note the argument order puts `lo` first:
+
+```rust
+// `Uuid::as_u64_pair()` returns (high, low); the setter takes (lo, hi).
+let (hi, lo) = uuid.as_u64_pair();
+buffer.column_uuid("trace_id", lo, hi)?;
+```
+
+Starting from the canonical 16 bytes instead, `hi` is a big-endian read of
+bytes 0..8 and `lo` a big-endian read of bytes 8..16. `column_uuid_opt` takes
+an `Option<(u64, u64)>` holding the same two halves in the same order. Passing
+whole canonical bytes is simpler with `Chunk::column_uuid`, which takes them
+directly.
+
 QWP cannot preserve nulls for `BOOLEAN`, `BYTE`, or `SHORT`. An absent value in
 one of those columns is received as `false` or `0`; use a wider nullable type
 when the distinction matters.
@@ -340,7 +356,7 @@ needs an entry in `data`, which the encoder ignores.
 | `BOOLEAN` | `column_bool(name, bits, row_count, validity)` | LSB-first bit-packed values |
 | `TIMESTAMP`, `TIMESTAMP_NS` | `column_ts(name, data, TimestampUnit, validity)` | Epoch `i64` values |
 | `DATE` | `column_date` | Epoch milliseconds |
-| `UUID` | `column_uuid` | `&[[u8; 16]]` in QuestDB wire order |
+| `UUID` | `column_uuid` | `&[[u8; 16]]` in canonical RFC-4122 order |
 | `LONG256` | `column_long256` | `&[[u8; 32]]` in little-endian limb order |
 | `IPv4` | `column_ipv4` | Host-order `u32` values |
 | `VARCHAR` | `column_str`, `column_str_large` | Arrow Utf8 offsets and bytes |


### PR DESCRIPTION
## Summary

Two UUID byte-order problems on the client pages.

The Rust buffer setter table listed `column_uuid` with nothing about `lo` and `hi`. Taking the client's own wire-layout wording as the caller-facing split silently stores a byte-reversed UUID, so the page now states that `hi` is the most significant 64 bits, shows the `Uuid::as_u64_pair()` call against the `(lo, hi)` argument order, and gives the canonical-bytes equivalent.

The chunk setter entries said "in QuestDB wire order" (Rust) and "16 bytes" (C and C++). Since questdb/c-questdb-client#186 the chunk setters take canonical RFC-4122 bytes and byte-swap internally, so both entries now say canonical RFC-4122 order.

Includes the September 2026 changelog entry.

## Dependencies

The chunk wording matches c-questdb-client `main`. That change is merged upstream but not in the published 7.0.0 crate, so it describes the next client release. The row-API wording applies to both.
