### PR TITLE
Document separated thread pools in the remaining pages

### DIFF
--- a/documentation/architecture/query-engine.md
+++ b/documentation/architecture/query-engine.md
@@ -59,8 +59,13 @@ to process data in table page frames for better CPU use.
   multi-core fashion. Some queries, for example those involving an index, are executed on a single
   thread. Other queries, like those involving `GROUP BY` and `SAMPLE BY`, execute a pipeline with some  single-threaded stages and some multi-threaded stages to avoid slow downs when groups are unbalanced.
 
-- **Worker pools:** QuestDB allows to configure different pools for specialized functions, like
-parsing incoming data, applying WAL file changes, handling PostgreSQL-Wire protocol, or responding to HTTP connections. By default, most tasks are handled by a shared worker pool.
+- **Worker pools:** QuestDB splits work across three thread pools that are sized
+independently: a network pool for HTTP, PostgreSQL and ILP server I/O, a query pool
+for parallel query execution, and a write pool for WAL apply jobs, table writes and
+materialized view refresh. Because query execution has its own pool, a burst of
+ingestion does not starve readers of CPU. Individual subsystems can still be given
+dedicated threads on top of this. See
+[shared workers](/docs/configuration/shared-workers/) for sizing.
 
 - **Query plan caching:**
   The system caches query plans for reuse within the same connection. (Query results are not

--- a/documentation/deployment/hetzner.md
+++ b/documentation/deployment/hetzner.md
@@ -337,7 +337,8 @@ questdb01$ docker restart questdb
 For comprehensive configuration options, see the [Configuration reference](/docs/configuration/overview/) documentation. Common production settings include:
 
 - **Connection limits**: `pg.connection.pool.size`
-- **Memory settings**: `shared.worker.count`
+- **Worker threads**: `shared.network.worker.count`, `shared.query.worker.count`,
+  `shared.write.worker.count`
 - **Security**: [TLS configuration](/docs/security/tls/)
 - **Authentication**: [RBAC setup](/docs/security/rbac/)
 

--- a/documentation/getting-started/capacity-planning.md
+++ b/documentation/getting-started/capacity-planning.md
@@ -188,12 +188,36 @@ for other database processes to use.
 
 ### CPU cores
 
-By default, QuestDB tries to use all available CPU cores.
+By default, QuestDB tries to use all available CPU cores. Assuming that the disk
+is not bottlenecked on IOPS, the throughput of read-only queries scales
+proportionally with the number of available cores, so a machine with more cores
+will provide better query performance.
+
+Work is divided across three independently sized thread pools, which is what you
+tune when one class of work needs more CPU than another:
+
+| Pool | Handles | Setting |
+| ---- | ------- | ------- |
+| Network | HTTP, PostgreSQL and ILP server I/O | `shared.network.worker.count` |
+| Query | Parallel query execution — filters, `GROUP BY` | `shared.query.worker.count` |
+| Write | WAL apply, table writes, materialized view refresh, housekeeping | `shared.write.worker.count` |
+
+Each pool defaults to roughly the CPU count, so the pools oversubscribe the
+machine by design and the OS scheduler arbitrates between them. That is a
+reasonable starting point. Move capacity deliberately when a workload is
+lopsided:
+
+- **Read-heavy** — raise `shared.query.worker.count` and lower
+  `shared.network.worker.count`, provided connection counts are modest.
+- **Ingestion-heavy** — raise `shared.write.worker.count` so WAL apply keeps up
+  with incoming data. A growing WAL apply backlog is the signal to watch.
+- **Many concurrent clients** — raise `shared.network.worker.count`, since I/O
+  rather than query execution is the constraint.
+
+On small machines, cutting a pool too far can leave a subsystem unable to make
+progress; keep at least two threads in each.
 [The guide on shared worker configuration](/docs/configuration/shared-workers/)
-explains how to change the default settings. Assuming that the disk is not
-bottlenecked on IOPS, the throughput of read-only queries scales proportionally
-with the number of available cores. As a result, a machine with more cores will
-provide better query performance.
+covers the defaults and the per-pool affinity settings.
 
 ### Writer page size
 


### PR DESCRIPTION
Partially addresses #229

`configuration/shared-workers.md` already documents the network, query and write pools in full, so nothing was needed there. This covers the other pages the issue lists, which still described the old single shared pool.

### What changed

**`architecture/query-engine.md`** — claimed *"By default, most tasks are handled by a shared worker pool."* That stopped being true when the pools were separated. Now describes the three pools and why the split matters: query execution has its own pool, so an ingestion burst does not starve readers of CPU.

**`getting-started/capacity-planning.md`** — the CPU cores section linked to the shared workers guide but never said cores are divided between pools, which is the thing you actually tune when a workload is lopsided. Adds a pool-to-setting table plus read-heavy / ingestion-heavy / many-clients guidance, and notes the pools oversubscribe the machine by default rather than partitioning it.

**`deployment/hetzner.md`** — recommended `shared.worker.count`, which no longer exists, and filed it under "Memory settings" rather than threading. This was the last reference to the old property outside the changelog.

### A note on the issue's links

The capacity planning and architecture URLs in the issue predate the docs restructure. `operations/capacity-planning` is now `getting-started/capacity-planning`, and the networking layer and data ingestion architecture pages no longer exist — their content sits in `architecture/query-engine.md` and `architecture/storage-engine.md`. I've updated where that content actually lives; happy to go further if some of it belongs elsewhere.

### Notes

- Pool descriptions and the two-thread floor are taken from `configuration/shared-workers.md` (the default formula is `max(2, ...)`), not invented.
- Left `pg.worker.count` in capacity planning alone — it is still valid, defaulting to `0` meaning "use the shared pool".