### PR TITLE
docs: document the Web Console path for copying schemas

### DIFF
--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -17,7 +17,7 @@ This page tracks significant updates to the QuestDB documentation.
 ### New
 
 - [Migrate QuestDB onto the Kubernetes Operator](/docs/enterprise-kubernetes-operator/getting-started/migrate/) - Move an existing Enterprise deployment onto the Operator with a replica-first cutover: restore the source backup, consume replication WAL, then promote after a controlled source drain
-- [Copy a schema to another instance](/docs/cookbook/operations/copy-schema-between-instances/) - Recreate one instance's tables, views, and materialized views on another from `SHOW CREATE DATABASE`, either by replaying the statements over the REST API or by dumping them to a `.sql` file, with `INCLUDE (SCHEMA)` and `INCLUDE (ACL)` for separating structure from permissions on Enterprise
+- [Copy a schema to another instance](/docs/cookbook/operations/copy-schema-between-instances/) - Recreate one instance's tables, views, and materialized views on another from `SHOW CREATE DATABASE`, either by replaying the statements over the REST API or by dumping them to a `.sql` file, with `INCLUDE (SCHEMA)` and `INCLUDE (ACL)` for separating structure from permissions on Enterprise, plus the Web Console schema explorer as a manual alternative and the ordering caveat that comes with it
 
 ### Updated
 

--- a/documentation/cookbook/operations/copy-schema-between-instances.md
+++ b/documentation/cookbook/operations/copy-schema-between-instances.md
@@ -151,11 +151,6 @@ alphabetically within each group, not in dependency order. Tables always precede
 materialized views, but a materialized view built on another materialized view
 can be emitted before its own base.
 
-Copying the [demo](https://demo.questdb.io) schema this way produces 5 of 13
-materialized views ahead of the view they read from, so `bbo_1d` arrives before
-`bbo_1h`, and a top-to-bottom paste fails on those statements. Reorder them by
-hand, or use `SHOW CREATE DATABASE`, which emits dependency order.
-
 :::
 
 :::info Related documentation

--- a/documentation/cookbook/operations/copy-schema-between-instances.md
+++ b/documentation/cookbook/operations/copy-schema-between-instances.md
@@ -131,10 +131,38 @@ Passwords and tokens are never dumped, so `CREATE USER` and
 `CREATE SERVICE ACCOUNT` statements replay without credentials. Set those on the
 target after the replay.
 
+## Manual alternative: copy from the Web Console
+
+For a one-off copy, or when you only want a few objects, the
+[schema explorer toolbar](/docs/getting-started/web-console/schema-explorer/#toolbar)
+puts the DDL on your clipboard with no scripting:
+
+1. Click **Select Mode**, the checkbox circle icon in the toolbar.
+2. Click **Select all**, the circle icon, or tick individual objects.
+3. Click **Copy schemas to clipboard**.
+
+Paste the result into an editor, or straight into the target's Web Console and
+run it. Selection mode exits once the copy succeeds.
+
+:::warning Reorder chained materialized views first
+
+The Web Console groups the copied statements by object type and sorts them
+alphabetically within each group, not in dependency order. Tables always precede
+materialized views, but a materialized view built on another materialized view
+can be emitted before its own base.
+
+Copying the [demo](https://demo.questdb.io) schema this way produces 5 of 13
+materialized views ahead of the view they read from, so `bbo_1d` arrives before
+`bbo_1h`, and a top-to-bottom paste fails on those statements. Reorder them by
+hand, or use `SHOW CREATE DATABASE`, which emits dependency order.
+
+:::
+
 :::info Related documentation
 
 - [`SHOW CREATE DATABASE`](/docs/query/sql/show/#show-create-database)
 - [REST API `/execute`](/docs/connect/compatibility/rest-api/#execute)
+- [Schema explorer](/docs/getting-started/web-console/schema-explorer/)
 - [Copy data between instances](/docs/cookbook/operations/copy-data-between-instances/)
 - [Backup and restore](/docs/operations/backup/)
 


### PR DESCRIPTION
## Summary

Follow-up to #550. Adds a manual alternative to the copy-schema recipe: the Web Console schema explorer can put the DDL for selected objects on the clipboard with no scripting, via Select Mode → Select all → Copy schemas to clipboard.

Includes a warning that this path is not dependency-ordered. The console groups statements by object type and sorts alphabetically within each group, so a materialized view built on another materialized view can be emitted before its own base.

`SHOW CREATE DATABASE` remains the recommended path since it emits dependency order.

Extends the existing changelog bullet rather than adding a second one, as the page is already listed as new under September.